### PR TITLE
dep ensure must be run from within a known GOPATH/src

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,8 @@
 before:
   hooks:
     - go get -u github.com/golang/dep/cmd/dep
+    # `dep ensure` must be run from within a known GOPATH/src.
+    - cd $(go env GOPATH)/src/github.com/helm/chart-releaser
     - dep ensure
 builds:
 - env:


### PR DESCRIPTION
Missed that when moving from circle to goreleaser before hook

Note this is to fix https://circleci.com/gh/helm/chart-releaser/1

Signed-off-by: Scott Rigby <scott@r6by.com>