### PR TITLE
Move gorelaser before hook to circle job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,14 @@
 version: 2
 jobs:
   release:
+    # `dep ensure` must be run from within a known GOPATH/src.
+    working_directory: /go/src/github.com/helm/chart-releaser
     docker:
       - image: circleci/golang:1.11
     steps:
       - checkout
+      - run: go get -u github.com/golang/dep/cmd/dep
+      - run: dep ensure
       # See https://github.com/goreleaser/get
       - run: curl -sL https://raw.githubusercontent.com/goreleaser/get/master/get | VERSION=v0.101.0 bash
 workflows:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,5 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
-before:
-  hooks:
-    - go get -u github.com/golang/dep/cmd/dep
-    # `dep ensure` must be run from within a known GOPATH/src.
-    - cd /go/src/github.com/helm/chart-releaser
-    - dep ensure
 builds:
 - env:
   - CGO_ENABLED=0


### PR DESCRIPTION
Signed-off-by: Scott Rigby <scott@r6by.com>

See #20, #21

There's not much visibility into goreleaser hook environments, so moving dep ensure step to circle. It's just as good here anyway.