### PR TITLE
Fix tag pattern for index command. See #17

### DIFF
--- a/pkg/index/main.go
+++ b/pkg/index/main.go
@@ -84,8 +84,8 @@ func Create(config *config.Options) error {
 		//fmt.Printf("found release %s\n", *r.TagName)
 		var packageName, packageVersion, packageURL string
 		for _, f := range r.Assets {
-			tagParts := strings.Split(*r.TagName, "+")
-			if len(tagParts) == 2 && *f.Name == fmt.Sprintf("%s-%s.tgz", tagParts[1], tagParts[0]) {
+			tagParts := strings.Split(*r.TagName, "-")
+			if len(tagParts) == 2 && *f.Name == fmt.Sprintf("%s-%s.tgz", tagParts[0], tagParts[1]) {
 				p := strings.TrimSuffix(*f.Name, filepath.Ext(*f.Name))
 				ps := strings.Split(p, "-")
 				packageName, packageVersion = ps[0], ps[1]


### PR DESCRIPTION
The `index` command was still looking for release tags with the semver spec item 10 (metadata) pattern (see #16 and #17), so the index file wasn't updating properly on the new non-semver release tags.

Signed-off-by: Scott Rigby <scott@r6by.com>