### PR TITLE
Use latest upstream instead of local branch for tags

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -97,7 +97,8 @@ main() {
 
     pushd "$SCRIPT_DIR" > /dev/null
 
-    git tag -a -m "Release $tag" "$tag" "${force[@]}"
+    git fetch "$remote"
+    git tag -a -m "Release $tag" "$tag" "$remote/master" "${force[@]}"
 
     if [[ -z "$skip_push" ]]; then
         git push "$remote" "refs/tags/$tag" "${force[@]}"


### PR DESCRIPTION
This is to avoid accidentally tagging the wrong commit if
the wrong branch is checked out.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>