### PR TITLE
Fix index file creation

### DIFF
--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -34,7 +34,7 @@ given GitHub repository's releases.
 		if err != nil {
 			return err
 		}
-		ghc := github.NewClient(config.Owner, config.Repo, config.Token)
+		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token)
 		releaser := releaser.NewReleaser(config, ghc)
 		_, err = releaser.UpdateIndexFile()
 		return err
@@ -42,14 +42,15 @@ given GitHub repository's releases.
 }
 
 func getRequiredIndexArgs() []string {
-	return []string{"owner", "repo"}
+	return []string{"owner", "git-repo", "charts-repo"}
 }
 
 func init() {
 	rootCmd.AddCommand(indexCmd)
 	flags := indexCmd.Flags()
 	flags.StringP("owner", "o", "", "GitHub username or organization")
-	flags.StringP("repo", "r", "", "GitHub repository")
+	flags.StringP("git-repo", "r", "", "GitHub repository")
+	flags.StringP("charts-repo", "c", "", "The URL to the charts repository")
 	flags.StringP("index-path", "i", ".cr-index/index.yaml", "Path to index file")
 	flags.StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
 	flags.StringP("token", "t", "", "GitHub Auth Token (only needed for private repos)")

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -31,20 +31,20 @@ var uploadCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		ghc := github.NewClient(config.Owner, config.Repo, config.Token)
+		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token)
 		releaser := releaser.NewReleaser(config, ghc)
 		return releaser.CreateReleases()
 	},
 }
 
 func getRequiredUploadArgs() []string {
-	return []string{"owner", "repo", "token"}
+	return []string{"owner", "git-repo", "token"}
 }
 
 func init() {
 	rootCmd.AddCommand(uploadCmd)
 	uploadCmd.Flags().StringP("owner", "o", "", "GitHub username or organization")
-	uploadCmd.Flags().StringP("repo", "r", "", "GitHub repository")
+	uploadCmd.Flags().StringP("git-repo", "r", "", "GitHub repository")
 	uploadCmd.Flags().StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
 	uploadCmd.Flags().StringP("token", "t", "", "GitHub Auth Token")
 }

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -53,15 +53,15 @@ func (c *DefaultHttpClient) Get(url string) (resp *http.Response, err error) {
 }
 
 type Releaser struct {
-	config *config.Options
-	github GitHub
+	config     *config.Options
+	github     GitHub
 	httpClient HttpClient
 }
 
 func NewReleaser(config *config.Options, github GitHub) *Releaser {
 	return &Releaser{
-		config: config,
-		github: github,
+		config:     config,
+		github:     github,
 		httpClient: &DefaultHttpClient{},
 	}
 }

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -41,15 +41,28 @@ type GitHub interface {
 	GetRelease(ctx context.Context, tag string) (*github.Release, error)
 }
 
+type HttpClient interface {
+	Get(url string) (*http.Response, error)
+}
+
+type DefaultHttpClient struct {
+}
+
+func (c *DefaultHttpClient) Get(url string) (resp *http.Response, err error) {
+	return http.Get(url)
+}
+
 type Releaser struct {
 	config *config.Options
 	github GitHub
+	httpClient HttpClient
 }
 
 func NewReleaser(config *config.Options, github GitHub) *Releaser {
 	return &Releaser{
 		config: config,
 		github: github,
+		httpClient: &DefaultHttpClient{},
 	}
 }
 
@@ -69,7 +82,7 @@ func (r *Releaser) UpdateIndexFile() (bool, error) {
 
 	var indexFile *repo.IndexFile
 
-	resp, err := http.Get(fmt.Sprintf("%s/index.yaml", r.config.ChartsRepo))
+	resp, err := r.httpClient.Get(fmt.Sprintf("%s/index.yaml", r.config.ChartsRepo))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -80,9 +80,9 @@ func TestReleaser_UpdateIndexFile(t *testing.T) {
 	fakeGitHub := new(FakeGitHub)
 
 	tests := []struct {
-		name      string
-		exists    bool
-		releaser  *Releaser
+		name     string
+		exists   bool
+		releaser *Releaser
 	}{
 		{
 			"index-file-exists",

--- a/pkg/releaser/testdata/repo/index.yaml
+++ b/pkg/releaser/testdata/repo/index.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+entries:
+  test-chart:
+  - apiVersion: v1
+    appVersion: "1.0"
+    created: "2019-03-29T22:50:44.754424+01:00"
+    description: A Helm chart for Kubernetes
+    digest: b61c67a17ac0215b45db5d4a60677d06993c772b1412c2dc32885ef7f49e4264
+    name: test-chart
+    urls:
+    - test-chart-0.1.0.tgz
+    version: 0.1.0
+generated: "2019-03-29T22:50:44.751503+01:00"


### PR DESCRIPTION
Fixes a regression that would discard an existing index file
in the charts repo and always create a new one that only
contained newly released charts.

Signed-off-by: Reinhard Naegele <unguiculus@gmail.com>