### PR TITLE
Bump Dockerfile Alpine base image to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 RUN apk --no-cache add ca-certificates
 


### PR DESCRIPTION
For [CVE-2019-14697](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14697)

Signed-off-by: Scott Rigby <scott@r6by.com>