### PR TITLE
Added BaseURL and UploadURL for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Flags:
   -h, --help                  help for upload
   -o, --owner string          GitHub username or organization
   -p, --package-path string   Path to directory with chart packages (default ".cr-release-packages")
-  -r, --repo string           GitHub repository
+  -r, --git-repo string       GitHub repository
   -t, --token string          GitHub Auth Token
+  -b, --git-base-url string   GitHub Base URL (only needed for private github)
+  -u, --git-upload-url string GitHub Upload URL (only needed for private github)
 
 Global Flags:
       --config string   Config file (default is $HOME/.chart-releaser.yaml)
@@ -87,8 +89,10 @@ Flags:
   -i, --index-path string     Path to index file (default ".cr-index/index.yaml")
   -o, --owner string          GitHub username or organization
   -p, --package-path string   Path to directory with chart packages (default ".cr-release-packages")
-  -r, --repo string           GitHub repository
+  -r, --git-repo string           GitHub repository
   -t, --token string          GitHub Auth Token (only needed for private repos)
+  -b, --git-base-url string   GitHub Base URL (only needed for private github)
+  -u, --git-upload-url string GitHub Upload URL (only needed for private github)
 
 Global Flags:
       --config string   Config file (default is $HOME/.chart-releaser.yaml)
@@ -114,14 +118,16 @@ The following example show various ways of configuring the same thing:
 
 #### CLI
 
-    cr upload --owner myaccount --repo helm-charts --package-path .deploy --token 123456789
+    cr upload --owner myaccount --git-repo helm-charts --package-path .deploy --token 123456789
 
 #### Environment Variables
 
     export CR_OWNER=myaccount
-    export CR_REPO=helm-charts
+    export CR_GIT_REPO=helm-charts
     export CR_PACKAGE_PATH=.deploy
     export CR_TOKEN="123456789"
+    export CR_GIT_BASE_URL="https://api.github.com/"
+    export CR_GIT_UPLOAD_URL="https://uploads.github.com/"
 
     cr upload
 
@@ -134,6 +140,8 @@ owner: myaccount
 repo: helm-charts
 package-path: .deploy
 token: 123456789
+git-base-url: https://api.github.com/
+git-upload-url: https://uploads.github.com/
 ```
 
 #### Config Usage

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Flags:
   -p, --package-path string   Path to directory with chart packages (default ".cr-release-packages")
   -r, --git-repo string       GitHub repository
   -t, --token string          GitHub Auth Token
-  -b, --git-base-url string   GitHub Base URL (only needed for private github)
-  -u, --git-upload-url string GitHub Upload URL (only needed for private github)
+  -b, --git-base-url string   GitHub Base URL (only needed for private GitHub)
+  -u, --git-upload-url string GitHub Upload URL (only needed for private GitHub)
 
 Global Flags:
       --config string   Config file (default is $HOME/.chart-releaser.yaml)
@@ -91,8 +91,8 @@ Flags:
   -p, --package-path string   Path to directory with chart packages (default ".cr-release-packages")
   -r, --git-repo string           GitHub repository
   -t, --token string          GitHub Auth Token (only needed for private repos)
-  -b, --git-base-url string   GitHub Base URL (only needed for private github)
-  -u, --git-upload-url string GitHub Upload URL (only needed for private github)
+  -b, --git-base-url string   GitHub Base URL (only needed for private GitHub)
+  -u, --git-upload-url string GitHub Upload URL (only needed for private GitHub)
 
 Global Flags:
       --config string   Config file (default is $HOME/.chart-releaser.yaml)

--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -54,6 +54,6 @@ func init() {
 	flags.StringP("index-path", "i", ".cr-index/index.yaml", "Path to index file")
 	flags.StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
 	flags.StringP("token", "t", "", "GitHub Auth Token (only needed for private repos)")
-	flags.StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private github)")
-	flags.StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private github)")
+	flags.StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private GitHub)")
+	flags.StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private GitHub)")
 }

--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -34,7 +34,7 @@ given GitHub repository's releases.
 		if err != nil {
 			return err
 		}
-		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token)
+		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token, config.GitBaseURL, config.GitUploadURL)
 		releaser := releaser.NewReleaser(config, ghc)
 		_, err = releaser.UpdateIndexFile()
 		return err
@@ -54,4 +54,6 @@ func init() {
 	flags.StringP("index-path", "i", ".cr-index/index.yaml", "Path to index file")
 	flags.StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
 	flags.StringP("token", "t", "", "GitHub Auth Token (only needed for private repos)")
+	flags.StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private github)")
+	flags.StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private github)")
 }

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -47,6 +47,6 @@ func init() {
 	uploadCmd.Flags().StringP("git-repo", "r", "", "GitHub repository")
 	uploadCmd.Flags().StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
 	uploadCmd.Flags().StringP("token", "t", "", "GitHub Auth Token")
-	uploadCmd.Flags().StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private github)")
-	uploadCmd.Flags().StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private github)")
+	uploadCmd.Flags().StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private GitHub)")
+	uploadCmd.Flags().StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private GitHub)")
 }

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -31,7 +31,7 @@ var uploadCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token)
+		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token, config.GitBaseURL, config.GitUploadURL)
 		releaser := releaser.NewReleaser(config, ghc)
 		return releaser.CreateReleases()
 	},
@@ -47,4 +47,6 @@ func init() {
 	uploadCmd.Flags().StringP("git-repo", "r", "", "GitHub repository")
 	uploadCmd.Flags().StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
 	uploadCmd.Flags().StringP("token", "t", "", "GitHub Auth Token")
+	uploadCmd.Flags().StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private github)")
+	uploadCmd.Flags().StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private github)")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,38 +3,29 @@ module github.com/helm/chart-releaser
 go 1.12
 
 require (
-	github.com/BurntSushi/toml v0.3.1
-	github.com/Masterminds/semver v1.4.2
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Songmu/retry v0.0.1
-	github.com/cyphar/filepath-securejoin v0.2.2
-	github.com/fsnotify/fsnotify v1.4.7
-	github.com/ghodss/yaml v1.0.0
-	github.com/gobwas/glob v0.2.3
-	github.com/golang/protobuf v1.3.1
+	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/google/go-querystring v1.0.0
-	github.com/hashicorp/hcl v1.0.0
-	github.com/inconshreveable/mousetrap v1.0.0
-	github.com/magiconair/properties v1.8.0
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/mapstructure v1.1.2
-	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.8.1
-	github.com/spf13/afero v1.2.1
-	github.com/spf13/cast v1.3.0
+	github.com/spf13/afero v1.2.1 // indirect
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/jwalterweatherman v1.1.0
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a
-	golang.org/x/net v0.0.0-20190313220215-9f648a60d977
+	golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a // indirect
+	golang.org/x/net v0.0.0-20190313220215-9f648a60d977 // indirect
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
-	golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f
-	golang.org/x/text v0.3.0
-	google.golang.org/appengine v1.4.0
-	gopkg.in/yaml.v2 v2.2.2
-	k8s.io/apimachinery v0.0.0-20190313115320-c9defaaddf6f
-	k8s.io/client-go v10.0.0+incompatible
+	golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f // indirect
+	k8s.io/apimachinery v0.0.0-20190313115320-c9defaaddf6f // indirect
+	k8s.io/client-go v10.0.0+incompatible // indirect
 	k8s.io/helm v2.13.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -81,7 +81,9 @@ golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f h1:yCrMx/EeIue0+Qca57bWZS7VX
 golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,12 +37,14 @@ var (
 )
 
 type Options struct {
-	Owner       string `mapstructure:"owner"`
-	GitRepo     string `mapstructure:"git-repo"`
-	ChartsRepo  string `mapstructure:"charts-repo"`
-	IndexPath   string `mapstructure:"index-path"`
-	PackagePath string `mapstructure:"package-path"`
-	Token       string `mapstructure:"token"`
+	Owner        string `mapstructure:"owner"`
+	GitRepo      string `mapstructure:"git-repo"`
+	ChartsRepo   string `mapstructure:"charts-repo"`
+	IndexPath    string `mapstructure:"index-path"`
+	PackagePath  string `mapstructure:"package-path"`
+	Token        string `mapstructure:"token"`
+	GitBaseURL   string `mapstructure:"git-base-url"`
+	GitUploadURL string `mapstructure:"git-upload-url"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, requiredFlags []string) (*Options, error) {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -16,8 +16,10 @@ package github
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Songmu/retry"
@@ -46,7 +48,7 @@ type Client struct {
 }
 
 // NewClient creates and initializes a new GitHubClient
-func NewClient(owner, repo, token string) *Client {
+func NewClient(owner, repo, token, baseURL, uploadURL string) *Client {
 	var client *github.Client
 	if token != "" {
 		ts := oauth2.StaticTokenSource(&oauth2.Token{
@@ -57,6 +59,21 @@ func NewClient(owner, repo, token string) *Client {
 	} else {
 		client = github.NewClient(nil)
 	}
+
+	if baseEndpoint, err := url.Parse(baseURL); err == nil {
+		if !strings.HasSuffix(baseEndpoint.Path, "/") {
+			baseEndpoint.Path += "/"
+		}
+		client.BaseURL = baseEndpoint
+	}
+
+	if uploadEndpoint, err := url.Parse(uploadURL); err == nil {
+		if !strings.HasSuffix(uploadEndpoint.Path, "/") {
+			uploadEndpoint.Path += "/"
+		}
+		client.UploadURL = uploadEndpoint
+	}
+
 	return &Client{
 		owner:  owner,
 		repo:   repo,


### PR DESCRIPTION
Address https://github.com/helm/chart-releaser/issues/14

As per https://github.com/google/go-github/blob/master/github/github.go#L296, the difference of public and enterprise github is values for `github base url` and `github upload url`.

In this PR, I just exposed two additional params for the same. The default values are also specified.