### PR TITLE
Add option to push to gh-pages

### DIFF
--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"github.com/helm/chart-releaser/pkg/config"
+	"github.com/helm/chart-releaser/pkg/git"
 	"github.com/helm/chart-releaser/pkg/github"
 	"github.com/helm/chart-releaser/pkg/releaser"
 	"github.com/spf13/cobra"
@@ -35,7 +36,7 @@ given GitHub repository's releases.
 			return err
 		}
 		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token, config.GitBaseURL, config.GitUploadURL)
-		releaser := releaser.NewReleaser(config, ghc)
+		releaser := releaser.NewReleaser(config, ghc, &git.Git{})
 		_, err = releaser.UpdateIndexFile()
 		return err
 	},
@@ -56,4 +57,7 @@ func init() {
 	flags.StringP("token", "t", "", "GitHub Auth Token (only needed for private repos)")
 	flags.StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private GitHub)")
 	flags.StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private GitHub)")
+	flags.String("pages-branch", "gh-pages", "The GitHub pages branch")
+	flags.Bool("push", false, "Push index.yaml to the GitHub Pages branch (must not be set if --pr is set)")
+	flags.Bool("pr", false, "Create a pull request for index.yaml against the GitHub Pages branch (must not be set if --push is set)")
 }

--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -58,6 +58,7 @@ func init() {
 	flags.StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private GitHub)")
 	flags.StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private GitHub)")
 	flags.String("pages-branch", "gh-pages", "The GitHub pages branch")
+	flags.String("remote", "origin", "The Git remote used when creating a local worktree for the GitHub Pages branch")
 	flags.Bool("push", false, "Push index.yaml to the GitHub Pages branch (must not be set if --pr is set)")
 	flags.Bool("pr", false, "Create a pull request for index.yaml against the GitHub Pages branch (must not be set if --push is set)")
 }

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"github.com/helm/chart-releaser/pkg/config"
+	"github.com/helm/chart-releaser/pkg/git"
 	"github.com/helm/chart-releaser/pkg/github"
 	"github.com/helm/chart-releaser/pkg/releaser"
 	"github.com/spf13/cobra"
@@ -32,7 +33,7 @@ var uploadCmd = &cobra.Command{
 			return err
 		}
 		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token, config.GitBaseURL, config.GitUploadURL)
-		releaser := releaser.NewReleaser(config, ghc)
+		releaser := releaser.NewReleaser(config, ghc, &git.Git{})
 		return releaser.CreateReleases()
 	},
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,7 @@ type Options struct {
 	PagesBranch  string `mapstructure:"pages-branch"`
 	Push         bool   `mapstructure:"push"`
 	PR           bool   `mapstructure:"pr"`
+	Remote       string `mapstructure:"remote"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, requiredFlags []string) (*Options, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,9 @@ type Options struct {
 	GitBaseURL   string `mapstructure:"git-base-url"`
 	GitUploadURL string `mapstructure:"git-upload-url"`
 	Commit       string `mapstructure:"commit"`
+	PagesBranch  string `mapstructure:"pages-branch"`
+	Push         bool   `mapstructure:"push"`
+	PR           bool   `mapstructure:"pr"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, requiredFlags []string) (*Options, error) {
@@ -87,6 +90,10 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, requiredFlags []strin
 	opts := &Options{}
 	if err := v.Unmarshal(opts); err != nil {
 		return nil, errors.Wrap(err, "Error unmarshaling configuration")
+	}
+
+	if opts.Push && opts.PR {
+		return nil, errors.New("specify either --push or --pr, but not both")
 	}
 
 	elem := reflect.ValueOf(opts).Elem()

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+type Git struct{}
+
+// AddWorktree creates a new Git worktree with a detached HEAD for the given committish and returns its path.
+func (g *Git) AddWorktree(workingDir string, committish string) (string, error) {
+	dir, err := ioutil.TempDir("", "chart-releaser-")
+	if err != nil {
+		return "", err
+	}
+	command := exec.Command("git", "worktree", "add", "--detach", dir, committish)
+
+	if err := runCommand(workingDir, command); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// RemoveWorktree removes the Git worktree with the given path.
+func (g *Git) RemoveWorktree(workingDir string, path string) error {
+	command := exec.Command("git", "worktree", "remove", path, "--force")
+	return runCommand(workingDir, command)
+}
+
+// Add runs 'git add' with the given args.
+func (g *Git) Add(workingDir string, args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no args specified")
+	}
+	addArgs := []string{"add"}
+	addArgs = append(addArgs, args...)
+	command := exec.Command("git", addArgs...)
+	return runCommand(workingDir, command)
+}
+
+// Commit runs 'git commit' with the given message. the commit is signed off.
+func (g *Git) Commit(workingDir string, message string) error {
+	command := exec.Command("git", "commit", "--message", message, "--signoff")
+	return runCommand(workingDir, command)
+}
+
+// Push runs 'git push' with the given args.
+func (g *Git) Push(workingDir string, args ...string) error {
+	pushArgs := []string{"push"}
+	pushArgs = append(pushArgs, args...)
+	command := exec.Command("git", pushArgs...)
+	return runCommand(workingDir, command)
+}
+
+func runCommand(workingDir string, command *exec.Cmd) error {
+	command.Dir = workingDir
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -122,6 +122,29 @@ func (c *Client) CreateRelease(ctx context.Context, input *Release) error {
 	return nil
 }
 
+// CreatePullRequest creates a pull request in the repository specified by repoURL.
+// The return value is the pull request URL.
+func (c *Client) CreatePullRequest(owner string, repo string, message string, head string, base string) (string, error) {
+	split := strings.SplitN(message, "\n", 2)
+	title := split[0]
+
+	pr := &github.NewPullRequest{
+		Title: &title,
+		Head:  &head,
+		Base:  &base,
+	}
+	if len(split) == 2 {
+		body := strings.TrimSpace(split[1])
+		pr.Body = &body
+	}
+
+	pullRequest, _, err := c.PullRequests.Create(context.Background(), owner, repo, pr)
+	if err != nil {
+		return "", err
+	}
+	return *pullRequest.HTMLURL, nil
+}
+
 // UploadAsset uploads specified assets to a given release object
 func (c *Client) uploadReleaseAsset(ctx context.Context, releaseID int64, filename string) error {
 

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -178,7 +178,7 @@ func (r *Releaser) UpdateIndexFile() (bool, error) {
 		return true, nil
 	}
 
-	worktree, err := r.git.AddWorktree("", "origin/"+r.config.PagesBranch)
+	worktree, err := r.git.AddWorktree("", r.config.Remote+"/"+r.config.PagesBranch)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -72,6 +72,11 @@ func (f *FakeGitHub) GetRelease(ctx context.Context, tag string) (*github.Releas
 	return release, nil
 }
 
+func (f *FakeGitHub) CreatePullRequest(owner string, repo string, message string, head string, base string) (string, error) {
+	f.Called(owner, repo, message, head, base)
+	return "https://github.com/owner/repo/pull/42", nil
+}
+
 func TestReleaser_UpdateIndexFile(t *testing.T) {
 	indexDir, _ := ioutil.TempDir(".", "index")
 	defer os.RemoveAll(indexDir)


### PR DESCRIPTION
This adds the option to push the `index.yaml` file, either directly to the GitHub Pages branch, which is now configurable, or via pull request.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>