### PR TITLE
Use dependency update instead of build

### DIFF
--- a/pkg/packager/packager.go
+++ b/pkg/packager/packager.go
@@ -74,7 +74,7 @@ func (p *Packager) CreatePackages() error {
 			RepositoryConfig: settings.RepositoryConfig,
 			RepositoryCache:  settings.RepositoryCache,
 		}
-		if err := downloadManager.Build(); err != nil {
+		if err := downloadManager.Update(); err != nil {
 			return err
 		}
 		packageRun, err := helmClient.Run(path, nil)


### PR DESCRIPTION
It turned out that `dependency build` requires that repos
of dependencies be added to the local config whereas
`dependency update` does not. We, thus, have to change the
logic here. An update always regenerates the lock file
which we don't really want as it is expected to be up to
date. However, adding repos is not easily possible. We'd
have to parse that information out of Chart.yaml/requirement.yaml.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>