### PR TITLE
Update releaser to regenerate generated field on index update

### DIFF
--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -182,6 +182,8 @@ func (r *Releaser) UpdateIndexFile() (bool, error) {
 	fmt.Printf("Updating index %s\n", r.config.IndexPath)
 	indexFile.SortEntries()
 
+	indexFile.Generated = time.Now()
+
 	if err := indexFile.WriteFile(r.config.IndexPath, 0644); err != nil {
 		return false, err
 	}

--- a/pkg/releaser/testdata/empty-repo/index.yaml
+++ b/pkg/releaser/testdata/empty-repo/index.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+entries:
+  some-other-chart:
+    - apiVersion: v1
+      appVersion: "1.0"
+      created: "2019-03-29T22:50:44.754424+01:00"
+      description: A Helm chart for Kubernetes
+      digest: b61c67a17ac0215b45db5d4a60677d06993c772b1412c2dc32885ef7f49e4264
+      name: other-chart
+      urls:
+        - other-chart-0.0.1.tgz
+      version: 0.0.1
+generated: "2019-03-29T22:50:44.751503+01:00"


### PR DESCRIPTION
Currently, the only time the `generated` field is ever written is when we invoke the `repo.NewIndexFile()` method. This means that contrary to what you would expect, the `generated` field is not updated when the index is updated.

This adds a single line change that calls `time.Now()` after we have determined that the index is to be updated, and updates the `generated` field before the index is written.

Closes #90 