### PR TITLE
Support creating charts as prereleases

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Flags:
   -h, --help                           help for upload
   -o, --owner string                   GitHub username or organization
   -p, --package-path string            Path to directory with chart packages (default ".cr-release-packages")
+      --prerelease bool                Create a prerelease instead of a release (default false)
       --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
   -t, --token string                   GitHub Auth Token
 

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -51,5 +51,6 @@ func init() {
 	uploadCmd.Flags().StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private GitHub)")
 	uploadCmd.Flags().StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private GitHub)")
 	uploadCmd.Flags().StringP("commit", "c", "", "Target commit for release")
+	uploadCmd.Flags().BoolP("prerelease", "", false, "Create a prerelease instead of a release")
 	uploadCmd.Flags().String("release-name-template", "{{ .Name }}-{{ .Version }}", "Go template for computing release names, using chart metadata")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,7 @@ type Options struct {
 	PagesBranch         string `mapstructure:"pages-branch"`
 	Push                bool   `mapstructure:"push"`
 	PR                  bool   `mapstructure:"pr"`
+	Prerelease          bool   `mapstructure:"prerelease"`
 	Remote              string `mapstructure:"remote"`
 	ReleaseNameTemplate string `mapstructure:"release-name-template"`
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -34,6 +34,7 @@ type Release struct {
 	Description string
 	Assets      []*Asset
 	Commit      string
+	Prerelease  bool
 }
 
 type Asset struct {
@@ -107,6 +108,7 @@ func (c *Client) CreateRelease(ctx context.Context, input *Release) error {
 		Body:            &input.Description,
 		TagName:         &input.Name,
 		TargetCommitish: &input.Commit,
+		Prerelease:      &input.Prerelease,
 	}
 
 	release, _, err := c.Repositories.CreateRelease(context.TODO(), c.owner, c.repo, req)

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -319,7 +319,8 @@ func (r *Releaser) CreateReleases() error {
 			Assets: []*github.Asset{
 				{Path: p},
 			},
-			Commit: r.config.Commit,
+			Commit:     r.config.Commit,
+			Prerelease: r.config.Prerelease,
 		}
 		provFile := fmt.Sprintf("%s.prov", p)
 		if _, err := os.Stat(provFile); err == nil {


### PR DESCRIPTION
If charts are released separately but within the application repository, it can cause friction and unhappiness for non-helm users as seen in https://github.com/kubernetes/kube-state-metrics/issues/1392 because users might rely on the Github API's `/releases/latest` for external automation.

The purpose of this PR is to provide the option to create helm charts as Github prereleases so the `/releases/latest` endpoint does not get updated if a github release gets created.