### PR TITLE
Open release file in retry loop

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -163,6 +163,7 @@ func (c *Client) uploadReleaseAsset(ctx context.Context, releaseID int64, filena
 		if err != nil {
 			return errors.Wrap(err, "failed to open file")
 		}
+		defer f.Close()
 		if _, _, err = c.Repositories.UploadReleaseAsset(context.TODO(), c.owner, c.repo, releaseID, opts, f); err != nil {
 			return errors.Wrapf(err, "failed to upload release asset: %s\n", filename)
 		}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -153,17 +153,16 @@ func (c *Client) uploadReleaseAsset(ctx context.Context, releaseID int64, filena
 		return errors.Wrap(err, "failed to get abs path")
 	}
 
-	f, err := os.Open(filename)
-	if err != nil {
-		return errors.Wrap(err, "failed to open file")
-	}
-
 	opts := &github.UploadOptions{
 		// Use base name by default
 		Name: filepath.Base(filename),
 	}
 
 	if err := retry.Retry(3, 3*time.Second, func() error {
+		f, err := os.Open(filename)
+		if err != nil {
+			return errors.Wrap(err, "failed to open file")
+		}
 		if _, _, err = c.Repositories.UploadReleaseAsset(context.TODO(), c.owner, c.repo, releaseID, opts, f); err != nil {
 			return errors.Wrapf(err, "failed to upload release asset: %s\n", filename)
 		}


### PR DESCRIPTION
Facing the same issue as described [here](https://github.com/tcnksm/ghr/pull/99)

The following error is being thrown when using the `chart-releaser` v1.2.0 inside a Github action in a `self-hosted` action runner (using Docker in Docker):
```
stat /path/to/release/foo-v0.0.5.tgz: use of closed file
```

Looks like a race between the file handler being closed and the `UploadReleaseAsset` being called. I would suggest to move this part into the `retry loop`.