### PR TITLE
Adding option to skip existing releases

### DIFF
--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -51,5 +51,6 @@ func init() {
 	uploadCmd.Flags().StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private GitHub)")
 	uploadCmd.Flags().StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private GitHub)")
 	uploadCmd.Flags().StringP("commit", "c", "", "Target commit for release")
+	uploadCmd.Flags().Bool("skip-existing", false, "Skip upload if release exists")
 	uploadCmd.Flags().String("release-name-template", "{{ .Name }}-{{ .Version }}", "Go template for computing release names, using chart metadata")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ type Options struct {
 	PR                  bool   `mapstructure:"pr"`
 	Remote              string `mapstructure:"remote"`
 	ReleaseNameTemplate string `mapstructure:"release-name-template"`
-	SkipExisting		bool   `mapstructure:"skip-existing"`
+	SkipExisting        bool   `mapstructure:"skip-existing"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, requiredFlags []string) (*Options, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,7 @@ type Options struct {
 	PR                  bool   `mapstructure:"pr"`
 	Remote              string `mapstructure:"remote"`
 	ReleaseNameTemplate string `mapstructure:"release-name-template"`
+	SkipExisting		bool   `mapstructure:"skip-existing"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, requiredFlags []string) (*Options, error) {

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -326,7 +326,12 @@ func (r *Releaser) CreateReleases() error {
 			asset := &github.Asset{Path: provFile}
 			release.Assets = append(release.Assets, asset)
 		}
-
+		if r.config.SkipExisting {
+			existingRelease, _ := r.github.GetRelease(context.TODO(), releaseName)
+			if existingRelease != nil && len(existingRelease.Assets) > 0 {
+				continue
+			}
+		}
 		if err := r.github.CreateRelease(context.TODO(), release); err != nil {
 			return errors.Wrap(err, "error creating GitHub release")
 		}

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -328,7 +328,7 @@ func (r *Releaser) CreateReleases() error {
 		}
 		if r.config.SkipExisting {
 			existingRelease, _ := r.github.GetRelease(context.TODO(), releaseName)
-			if existingRelease != nil && len(existingRelease.Assets) > 0 {
+			if existingRelease != nil {
 				continue
 			}
 		}


### PR DESCRIPTION
I just ran into bug #65 with the exact same use case that the author of the bug reported. I have a repository for all the charts in my organization what I want is for a CI pipeline to automatically push the charts that have changed. I am trying to keep the CI logic simple and cr is helping me a lot but I do have the issue that not all charts are changing at the same time. What I would like is to be able to tell cr to skip charts that have a name/tag that is already released (a warning can be added).

This seems to be simple, I just added a "skip" flag and if a release already exists it just skips it.

I did not add a test yet since I would like feedback on it before moving forward. Any thoughts on this fix?

thank you for CR!!