### PR TITLE
bug: add git to docker image to run cr index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates git
 
 COPY cr /usr/local/bin/cr
 


### PR DESCRIPTION
In order to run `cr index` from docker image with `--push` or `--pr` you need git.