### PR TITLE
Added releaseName to error returned on gh failure

### DIFF
--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -333,7 +333,7 @@ func (r *Releaser) CreateReleases() error {
 			}
 		}
 		if err := r.github.CreateRelease(context.TODO(), release); err != nil {
-			return errors.Wrap(err, "error creating GitHub release")
+			return errors.Wrapf(err, "error creating GitHub release %s", releaseName)
 		}
 	}
 


### PR DESCRIPTION
If GH fails to upload, you get errors which don't really help much, like:

```
Error: error creating GitHub release: POST https://api.github.com/repos/garethahealy/helm-charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```

Adding in the releaseName would help diagnose what's wrong.