### PR TITLE
docker fix entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ COPY cr /usr/local/bin/cr
 # Ensure that the binary is available on path and is executable
 RUN cr --help
 
-ENTRYPOINT /usr/local/bin/cr
+ENTRYPOINT [ "/usr/local/bin/cr" ]


### PR DESCRIPTION
Add missing brackets otherwise, we need to set the entry point when running

/kind bug

Fixes: https://github.com/helm/chart-releaser/issues/126

## Tests
built locally

```
$ docker run quay.io/helmpack/chart-releaser:latest upload --help
Upload Helm chart packages to GitHub Releases

Usage:
  cr upload [flags]

Flags:
  -c, --commit string                  Target commit for release
  -b, --git-base-url string            GitHub Base URL (only needed for private GitHub) (default "https://api.github.com/")
  -r, --git-repo string                GitHub repository
  -u, --git-upload-url string          GitHub Upload URL (only needed for private GitHub) (default "https://uploads.github.com/")
  -h, --help                           help for upload
  -o, --owner string                   GitHub username or organization
  -p, --package-path string            Path to directory with chart packages (default ".cr-release-packages")
      --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
      --skip-existing                  Skip upload if release exists
  -t, --token string                   GitHub Auth Token

Global Flags:
      --config string   Config file (default is $HOME/.cr.yaml)
```

before:

```
$ docker run quay.io/helmpack/chart-releaser:v1.2.1 upload --help
Unable to find image 'quay.io/helmpack/chart-releaser:v1.2.1' locally
v1.2.1: Pulling from helmpack/chart-releaser
540db60ca938: Already exists
5c77e6f3bf05: Already exists
c62388eef922: Already exists
Digest: sha256:4b6f25b77df0e4ef5176aaa7db977be42e586ced8de67c07cf94988d0a09e22f
Status: Downloaded newer image for quay.io/helmpack/chart-releaser:v1.2.1

Create Helm chart repositories on GitHub Pages by uploading Chart packages
and Chart metadata to GitHub Releases and creating a suitable index file

Usage:
  cr [command]

Available Commands:
  help        Help about any command
  index       Update Helm repo index.yaml for the given GitHub repo
  package     Package Helm charts
  upload      Upload Helm chart packages to GitHub Releases
  version     Print version information

Flags:
      --config string   Config file (default is $HOME/.cr.yaml)
  -h, --help            help for cr

Use "cr [command] --help" for more information about a command.
```