### PR TITLE
Deprecate cr index "charts-repo" flag. Instead read index.yaml from git repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ Usage:
   cr [command]
 
 Available Commands:
+  completion  generate the autocompletion script for the specified shell
   help        Help about any command
   index       Update Helm repo index.yaml for the given GitHub repo
-  upload      Upload Helm chart packages to GitHub Releases
   package     Package Helm charts
+  upload      Upload Helm chart packages to GitHub Releases
   version     Print version information
 
 Flags:
@@ -101,7 +102,6 @@ Usage:
   cr index [flags]
 
 Flags:
-  -c, --charts-repo string             The URL to the charts repository
   -b, --git-base-url string            GitHub Base URL (only needed for private GitHub) (default "https://api.github.com/")
   -r, --git-repo string                GitHub repository
   -u, --git-upload-url string          GitHub Upload URL (only needed for private GitHub) (default "https://uploads.github.com/")
@@ -109,7 +109,11 @@ Flags:
   -i, --index-path string              Path to index file (default ".cr-index/index.yaml")
   -o, --owner string                   GitHub username or organization
   -p, --package-path string            Path to directory with chart packages (default ".cr-release-packages")
+      --pages-branch string            The GitHub pages branch (default "gh-pages")
+      --pr                             Create a pull request for index.yaml against the GitHub Pages branch (must not be set if --push is set)
+      --push                           Push index.yaml to the GitHub Pages branch (must not be set if --pr is set)
       --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
+      --remote string                  The Git remote used when creating a local worktree for the GitHub Pages branch (default "origin")
   -t, --token string                   GitHub Auth Token (only needed for private repos)
 
 Global Flags:

--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -42,7 +42,7 @@ given GitHub repository's releases.
 			fmt.Fprintf(os.Stderr, "ATTENTION: Flag --charts-repo is deprecated. It does not have any effect.\n"+
 				"The index.yaml is read from the '%s' branch instead.\n"+
 				"Loading index.yaml directly from the charts repository lead to problems as there is a delay between\n"+
-				"pushing to the github pages branch until things apear online.\n"+
+				"pushing to the GitHub pages branch until things appear online.\n"+
 				"The flag will be removed with the next major release.", config.PagesBranch)
 		}
 

--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -15,11 +15,13 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/helm/chart-releaser/pkg/config"
 	"github.com/helm/chart-releaser/pkg/git"
 	"github.com/helm/chart-releaser/pkg/github"
 	"github.com/helm/chart-releaser/pkg/releaser"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 // indexCmd represents the index command
@@ -35,6 +37,15 @@ given GitHub repository's releases.
 		if err != nil {
 			return err
 		}
+
+		if len(config.ChartsRepo) > 0 {
+			fmt.Fprintf(os.Stderr, "ATTENTION: Flag --charts-repo is deprecated. It does not have any effect.\n"+
+				"The index.yaml is read from the '%s' branch instead.\n"+
+				"Loading index.yaml directly from the charts repository lead to problems as there is a delay between\n"+
+				"pushing to the github pages branch until things apear online.\n"+
+				"The flag will be removed with the next major release.", config.PagesBranch)
+		}
+
 		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token, config.GitBaseURL, config.GitUploadURL)
 		releaser := releaser.NewReleaser(config, ghc, &git.Git{})
 		_, err = releaser.UpdateIndexFile()
@@ -51,6 +62,8 @@ func init() {
 	flags := indexCmd.Flags()
 	flags.StringP("owner", "o", "", "GitHub username or organization")
 	flags.StringP("git-repo", "r", "", "GitHub repository")
+	flags.StringP("charts-repo", "c", "", "The URL to the charts repository")
+	_ = flags.MarkHidden("charts-repo")
 	flags.StringP("index-path", "i", ".cr-index/index.yaml", "Path to index file")
 	flags.StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
 	flags.StringP("token", "t", "", "GitHub Auth Token (only needed for private repos)")

--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -43,7 +43,7 @@ given GitHub repository's releases.
 }
 
 func getRequiredIndexArgs() []string {
-	return []string{"owner", "git-repo", "charts-repo"}
+	return []string{"owner", "git-repo"}
 }
 
 func init() {
@@ -51,7 +51,6 @@ func init() {
 	flags := indexCmd.Flags()
 	flags.StringP("owner", "o", "", "GitHub username or organization")
 	flags.StringP("git-repo", "r", "", "GitHub repository")
-	flags.StringP("charts-repo", "c", "", "The URL to the charts repository")
 	flags.StringP("index-path", "i", ".cr-index/index.yaml", "Path to index file")
 	flags.StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
 	flags.StringP("token", "t", "", "GitHub Auth Token (only needed for private repos)")

--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -16,12 +16,13 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/helm/chart-releaser/pkg/config"
 	"github.com/helm/chart-releaser/pkg/git"
 	"github.com/helm/chart-releaser/pkg/github"
 	"github.com/helm/chart-releaser/pkg/releaser"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // indexCmd represents the index command

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ var (
 type Options struct {
 	Owner               string `mapstructure:"owner"`
 	GitRepo             string `mapstructure:"git-repo"`
+	ChartsRepo          string `mapstructure:"charts-repo"`
 	IndexPath           string `mapstructure:"index-path"`
 	PackagePath         string `mapstructure:"package-path"`
 	Sign                bool   `mapstructure:"sign"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,7 +40,6 @@ var (
 type Options struct {
 	Owner               string `mapstructure:"owner"`
 	GitRepo             string `mapstructure:"git-repo"`
-	ChartsRepo          string `mapstructure:"charts-repo"`
 	IndexPath           string `mapstructure:"index-path"`
 	PackagePath         string `mapstructure:"package-path"`
 	Sign                bool   `mapstructure:"sign"`

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -78,18 +78,16 @@ func (c *DefaultHttpClient) Get(url string) (resp *http.Response, err error) {
 }
 
 type Releaser struct {
-	config     *config.Options
-	github     GitHub
-	httpClient HttpClient
-	git        Git
+	config *config.Options
+	github GitHub
+	git    Git
 }
 
 func NewReleaser(config *config.Options, github GitHub, git Git) *Releaser {
 	return &Releaser{
-		config:     config,
-		github:     github,
-		httpClient: &DefaultHttpClient{},
-		git:        git,
+		config: config,
+		github: github,
+		git:    git,
 	}
 }
 
@@ -107,35 +105,22 @@ func (r *Releaser) UpdateIndexFile() (bool, error) {
 		}
 	}
 
-	var indexFile *repo.IndexFile
-
-	resp, err := r.httpClient.Get(fmt.Sprintf("%s/index.yaml", r.config.ChartsRepo))
+	fmt.Printf("Loading index file from git repository %s\n", r.config.IndexPath)
+	worktree, err := r.git.AddWorktree("", r.config.Remote+"/"+r.config.PagesBranch)
 	if err != nil {
 		return false, err
 	}
+	defer r.git.RemoveWorktree("", worktree) // nolint: errcheck
+	indexYamlPath := filepath.Join(worktree, "index.yaml")
 
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusOK {
-		out, err := os.Create(r.config.IndexPath)
-		if err != nil {
-			return false, err
-		}
-		defer out.Close()
-
-		_, err = io.Copy(out, resp.Body)
-		if err != nil {
-			return false, err
-		}
-
-		fmt.Printf("Using existing index at %s\n", r.config.IndexPath)
-		indexFile, err = repo.LoadIndexFile(r.config.IndexPath)
-		if err != nil {
-			return false, err
-		}
-	} else {
-		fmt.Printf("UpdateIndexFile new index at %s\n", r.config.IndexPath)
+	var indexFile *repo.IndexFile
+	if _, err := os.Stat(indexYamlPath); errors.Is(err, os.ErrNotExist) {
 		indexFile = repo.NewIndexFile()
+	} else {
+		indexFile, err = repo.LoadIndexFile(indexYamlPath)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	// We have to explicitly glob for *.tgz files only. If GPG signing is enabled,
@@ -203,13 +188,6 @@ func (r *Releaser) UpdateIndexFile() (bool, error) {
 		return true, nil
 	}
 
-	worktree, err := r.git.AddWorktree("", r.config.Remote+"/"+r.config.PagesBranch)
-	if err != nil {
-		return false, err
-	}
-	defer r.git.RemoveWorktree("", worktree) // nolint: errcheck
-
-	indexYamlPath := filepath.Join(worktree, "index.yaml")
 	if err := copyFile(r.config.IndexPath, indexYamlPath); err != nil {
 		return false, err
 	}

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -114,13 +114,16 @@ func (r *Releaser) UpdateIndexFile() (bool, error) {
 	indexYamlPath := filepath.Join(worktree, "index.yaml")
 
 	var indexFile *repo.IndexFile
-	if _, err := os.Stat(indexYamlPath); errors.Is(err, os.ErrNotExist) {
-		indexFile = repo.NewIndexFile()
-	} else {
+	_, err = os.Stat(indexYamlPath)
+	if err == nil {
 		indexFile, err = repo.LoadIndexFile(indexYamlPath)
 		if err != nil {
 			return false, err
 		}
+	} else if errors.Is(err, os.ErrNotExist) {
+		indexFile = repo.NewIndexFile()
+	} else {
+		return false, err
 	}
 
 	// We have to explicitly glob for *.tgz files only. If GPG signing is enabled,


### PR DESCRIPTION
So far the index.yaml was loaded directly from the chart repository. In case of GitHub pages that's https://<user or org>.github.io/<repo>
The problem with this approach is that GitHub pages use a Content Delivery Network. So the index.yaml files fetched from there might be outdated as there is a delay between a git push to the gh-pages branch until the content is visible.
This delay might lead to the situation that one downloads an old index file from and updated that one instead of the most recent index.yaml.

For the grafana repository that resulted in already released charts being removed again.
- https://github.com/grafana/helm-charts/issues/783
- https://github.com/grafana/helm-charts/pull/796

This PR resolves that issue by reading the index.yaml from the gh_pages branch of the repository. The branch needs to be up-to-date anyhow if you want to create a PR or directly push the changes.

It should also be fine for the chart-releaser-action as it uses a fetch-depth: 0 to clone the whole repository.

```
jobs:
  release:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v2
        with:
          fetch-depth: 0
```

Fixes: #143