### PR TITLE
add pre-release flag on upload command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Flags:
   -p, --package-path string            Path to directory with chart packages (default ".cr-release-packages")
       --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
       --release-notes-file string      Markdown file with chart release notes. If it is set to empty string, or the file is not found, the chart description will be used instead
+      --pre-release                    Whether to mark release as pre-release
       --skip-existing                  Skip upload if release exists
   -t, --token string                   GitHub Auth Token
 

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -34,7 +34,7 @@ var uploadCmd = &cobra.Command{
 		}
 		ghc := github.NewClient(config.Owner, config.GitRepo, config.Token, config.GitBaseURL, config.GitUploadURL)
 		releaser := releaser.NewReleaser(config, ghc, &git.Git{})
-		return releaser.CreateReleases()
+		return releaser.CreateReleases(config.PreRelease)
 	},
 }
 
@@ -51,6 +51,7 @@ func init() {
 	uploadCmd.Flags().StringP("git-base-url", "b", "https://api.github.com/", "GitHub Base URL (only needed for private GitHub)")
 	uploadCmd.Flags().StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private GitHub)")
 	uploadCmd.Flags().StringP("commit", "c", "", "Target commit for release")
+	uploadCmd.Flags().Bool("pre-release", false, "Whether to mark release as pre-release")
 	uploadCmd.Flags().Bool("skip-existing", false, "Skip upload if release exists")
 	uploadCmd.Flags().String("release-name-template", "{{ .Name }}-{{ .Version }}", "Go template for computing release names, using chart metadata")
 	uploadCmd.Flags().String("release-notes-file", "", "Markdown file with chart release notes. "+

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,7 @@ type Options struct {
 	PR                  bool   `mapstructure:"pr"`
 	Remote              string `mapstructure:"remote"`
 	ReleaseNameTemplate string `mapstructure:"release-name-template"`
+	PreRelease          bool   `mapstructure:"pre-release"`
 	SkipExisting        bool   `mapstructure:"skip-existing"`
 	ReleaseNotesFile    string `mapstructure:"release-notes-file"`
 }

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -34,6 +34,7 @@ type Release struct {
 	Description string
 	Assets      []*Asset
 	Commit      string
+	PreRelease  bool
 }
 
 type Asset struct {
@@ -107,6 +108,7 @@ func (c *Client) CreateRelease(ctx context.Context, input *Release) error {
 		Body:            &input.Description,
 		TagName:         &input.Name,
 		TargetCommitish: &input.Commit,
+		Prerelease:      &input.PreRelease,
 	}
 
 	release, _, err := c.Repositories.CreateRelease(context.TODO(), c.owner, c.repo, req)

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -309,7 +309,7 @@ func (r *Releaser) addToIndexFile(indexFile *repo.IndexFile, url string) error {
 }
 
 // CreateReleases finds and uploads Helm chart packages to GitHub
-func (r *Releaser) CreateReleases() error {
+func (r *Releaser) CreateReleases(preRelease bool) error {
 	packages, err := r.getListOfPackages(r.config.PackagePath)
 	if err != nil {
 		return err
@@ -335,7 +335,8 @@ func (r *Releaser) CreateReleases() error {
 			Assets: []*github.Asset{
 				{Path: p},
 			},
-			Commit: r.config.Commit,
+			Commit:     r.config.Commit,
+			PreRelease: preRelease,
 		}
 		provFile := fmt.Sprintf("%s.prov", p)
 		if _, err := os.Stat(provFile); err == nil {

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -291,7 +291,7 @@ func TestReleaser_CreateReleases(t *testing.T) {
 				github: fakeGitHub,
 			}
 			fakeGitHub.On("CreateRelease", mock.Anything, mock.Anything).Return(nil)
-			err := r.CreateReleases()
+			err := r.CreateReleases(false)
 			if tt.error {
 				assert.Error(t, err)
 				assert.Nil(t, fakeGitHub.release)
@@ -357,7 +357,7 @@ func TestReleaser_ReleaseNotes(t *testing.T) {
 				github: fakeGitHub,
 			}
 			fakeGitHub.On("CreateRelease", mock.Anything, mock.Anything).Return(nil)
-			err := r.CreateReleases()
+			err := r.CreateReleases(false)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedReleaseNotes, fakeGitHub.release.Description)
 		})

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -252,6 +252,7 @@ func TestReleaser_CreateReleases(t *testing.T) {
 		chart       string
 		version     string
 		commit      string
+		preRelease  bool
 		error       bool
 	}{
 		{
@@ -260,6 +261,7 @@ func TestReleaser_CreateReleases(t *testing.T) {
 			"test-chart",
 			"0.1.0",
 			"",
+			false,
 			true,
 		},
 		{
@@ -269,6 +271,7 @@ func TestReleaser_CreateReleases(t *testing.T) {
 			"0.1.0",
 			"",
 			false,
+			false,
 		},
 		{
 			"valid-package-path-with-commit",
@@ -276,6 +279,16 @@ func TestReleaser_CreateReleases(t *testing.T) {
 			"test-chart",
 			"0.1.0",
 			"5e239bd19fbefb9eb0181ecf0c7ef73b8fe2753c",
+			false,
+			false,
+		},
+		{
+			"valid-package-pre-release",
+			"testdata/release-packages",
+			"test-chart",
+			"0.1.0",
+			"",
+			true,
 			false,
 		},
 	}
@@ -291,7 +304,7 @@ func TestReleaser_CreateReleases(t *testing.T) {
 				github: fakeGitHub,
 			}
 			fakeGitHub.On("CreateRelease", mock.Anything, mock.Anything).Return(nil)
-			err := r.CreateReleases(false)
+			err := r.CreateReleases(tt.preRelease)
 			if tt.error {
 				assert.Error(t, err)
 				assert.Nil(t, fakeGitHub.release)
@@ -306,6 +319,7 @@ func TestReleaser_CreateReleases(t *testing.T) {
 				assert.Len(t, fakeGitHub.release.Assets, 1)
 				assert.Equal(t, assetPath, fakeGitHub.release.Assets[0].Path)
 				assert.Equal(t, tt.commit, fakeGitHub.release.Commit)
+				assert.Equal(t, tt.preRelease, fakeGitHub.release.PreRelease)
 				fakeGitHub.AssertNumberOfCalls(t, "CreateRelease", 1)
 			}
 		})


### PR DESCRIPTION
We would like to have an option to mark chart release as pre-release so we have more control.
- first we publish charts to github pages and mark release as pre release
- when we test the release we un-tick pre-release, this is picked up by github action that copies the charts to "prod" chart repo