### PR TITLE
Added a log if release notes are not found in chart package

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Flags:
   -o, --owner string                   GitHub username or organization
   -p, --package-path string            Path to directory with chart packages (default ".cr-release-packages")
       --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
-      --release-notes-file string      Markdown file with chart release notes. If it is set to empty string, or the file is not found, the chart description will be used instead
+      --release-notes-file string      Markdown file with chart release notes. If it is set to empty string, or the file is not found, the chart description will be used instead. The file is read from the chart package
       --skip-existing                  Skip upload if release exists
   -t, --token string                   GitHub Auth Token
 

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -54,5 +54,5 @@ func init() {
 	uploadCmd.Flags().Bool("skip-existing", false, "Skip upload if release exists")
 	uploadCmd.Flags().String("release-name-template", "{{ .Name }}-{{ .Version }}", "Go template for computing release names, using chart metadata")
 	uploadCmd.Flags().String("release-notes-file", "", "Markdown file with chart release notes. "+
-		"If it is set to empty string, or the file is not found, the chart description will be used instead")
+		"If it is set to empty string, or the file is not found, the chart description will be used instead. The file is read from the chart package")
 }

--- a/doc/cr_upload.md
+++ b/doc/cr_upload.md
@@ -21,7 +21,7 @@ cr upload [flags]
   -o, --owner string                   GitHub username or organization
   -p, --package-path string            Path to directory with chart packages (default ".cr-release-packages")
       --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
-      --release-notes-file string      Markdown file with chart release notes. If it is set to empty string, or the file is not found, the chart description will be used instead
+      --release-notes-file string      Markdown file with chart release notes. If it is set to empty string, or the file is not found, the chart description will be used instead. The file is read from the chart package
       --skip-existing                  Skip upload if release exists
   -t, --token string                   GitHub Auth Token
 ```

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -263,6 +263,7 @@ func (r *Releaser) getReleaseNotes(chart *chart.Chart) string {
 				return string(f.Data)
 			}
 		}
+		fmt.Printf("The release note file %q, is not present in the chart package\n", r.config.ReleaseNotesFile)
 	}
 	return chart.Metadata.Description
 }


### PR DESCRIPTION
This PR is simply added an extra line of code to warn the user that the file specified is not found.

I spent 30 minutes to understand that the release note file had to be placed inside the chart package and I ended up reading the source code. Therefore I updated the readme as well