### PR TITLE
Ignore third party files added in the release.

### DIFF
--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -68,7 +68,7 @@ type Git interface {
 type DefaultHTTPClient struct{}
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
-var chartAssetFileExtension = ".tgz"
+const chartAssetFileExtension = ".tgz"
 
 func init() {
 	rand.Seed(time.Now().UnixNano())

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -68,6 +68,7 @@ type Git interface {
 type DefaultHTTPClient struct{}
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
 const chartAssetFileExtension = ".tgz"
 
 func init() {

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -68,6 +68,7 @@ type Git interface {
 type DefaultHTTPClient struct{}
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+var chartAssetFileExtension = ".tgz"
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -171,6 +172,10 @@ func (r *Releaser) UpdateIndexFile() (bool, error) {
 		for _, asset := range release.Assets {
 			downloadURL, _ := url.Parse(asset.URL)
 			name := filepath.Base(downloadURL.Path)
+			// Ignore any other files added in the release by the users.
+			if filepath.Ext(name) != chartAssetFileExtension {
+				continue
+			}
 			baseName := strings.TrimSuffix(name, filepath.Ext(name))
 			tagParts := r.splitPackageNameAndVersion(baseName)
 			packageName, packageVersion := tagParts[0], tagParts[1]

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -86,6 +86,10 @@ func (f *FakeGitHub) GetRelease(ctx context.Context, tag string) (*github.Releas
 				Path: "testdata/release-packages/test-chart-0.1.0.tgz",
 				URL:  "https://myrepo/charts/test-chart-0.1.0.tgz",
 			},
+			{
+				Path: "testdata/release-packages/third-party-file-0.1.0.txt",
+				URL:  "https://myrepo/charts/third-party-file-0.1.0.txt",
+			},
 		},
 	}
 	return release, nil


### PR DESCRIPTION
Update the function used to update the index to ignore any file that does not have the chart asset file extension (.tgz). This is necessary because chart-release fails with users add another kind of files in chart release.

Fix #233 