### PR TITLE
Peform single push on upload in case of multiple releases

### DIFF
--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -308,6 +308,9 @@ func (r *Releaser) CreateReleases() error {
 	defer r.git.RemoveWorktree("", worktree) // nolint: errcheck
 
 	packages, err := r.getListOfPackages(r.config.PackagePath)
+	if err != nil {
+		return err
+	}
 
 	if len(packages) == 0 {
 		return errors.Errorf("no charts found at %s", r.config.PackagePath)

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -510,13 +510,17 @@ func TestReleaser_ReleaseNotes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeGitHub := new(FakeGitHub)
+			fakeGit := new(FakeGit)
 			r := &Releaser{
 				config: &config.Options{
 					PackagePath:      "testdata/release-packages",
 					ReleaseNotesFile: tt.releaseNotesFile,
 				},
 				github: fakeGitHub,
+				git:    fakeGit,
 			}
+			fakeGit.On("AddWorktree", mock.Anything, mock.Anything).Return("/tmp/chart-releaser-012345678", nil)
+			fakeGit.On("RemoveWorktree", mock.Anything, mock.Anything).Return(nil)
 			fakeGitHub.On("CreateRelease", mock.Anything, mock.Anything).Return(nil)
 			err := r.CreateReleases()
 			assert.NoError(t, err)


### PR DESCRIPTION
Resolves the problem [mentioned](https://github.com/helm/chart-releaser/pull/123#discussion_r1148913202) in [this](https://github.com/helm/chart-releaser/pull/123) PR

Lets say you want to upload more than one release and place it near the index file. After the first push your second push will be rejected with an error "Updates were rejected because a pushed branch tip is behind its remote". So either you need to pull changes before push another release or push all releases once in the end of upload action.

In case of pulling changes and pushing every release separately you'll face github will launch as many "pages build and deployment" actions as there are new releases you want to upload. All except one will be canceled, but the list of actions will look like a mess.

So the most efficient way is to make single push in the end of upload.