### PR TITLE
TIDY unused packages-with-index HTTPClient

### DIFF
--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -53,11 +52,6 @@ type GitHub interface {
 	CreatePullRequest(owner string, repo string, message string, head string, base string) (string, error)
 }
 
-type HTTPClient interface {
-	Get(url string) (*http.Response, error)
-	GetWithToken(url string, token string) (*http.Response, error)
-}
-
 type Git interface {
 	AddWorktree(workingDir string, committish string) (string, error)
 	RemoveWorktree(workingDir string, path string) error
@@ -68,18 +62,12 @@ type Git interface {
 	GetPushURL(remote string, token string) (string, error)
 }
 
-type DefaultHTTPClient struct{}
-
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
 const chartAssetFileExtension = ".tgz"
 
 func init() {
 	rand.New(rand.NewSource(time.Now().UnixNano())) // nolint: gosec
-}
-
-func (c *DefaultHTTPClient) Get(url string) (resp *http.Response, err error) {
-	return http.Get(url) // nolint: gosec
 }
 
 type Releaser struct {


### PR DESCRIPTION
It appears some extra code was added via [PR](https://github.com/helm/chart-releaser/pull/123).

@annabarnes1138 had started to [add](https://github.com/helm/chart-releaser/pull/123/commits/9763971f4c2584c479d6b428a068678dca2d93b3) (WIP) functionality related to authenticating with github via a token but part of it was [removed](https://github.com/helm/chart-releaser/pull/123/commits/a9a8929f8f7841dc17d21a806fee5aa3edabe8d1) by @cpanato 

TLDR authenticating via token is [done elsewhere](https://github.com/helm/chart-releaser/blob/main/pkg/github/github.go#L56-L64) so this code isn't used.