### PR TITLE
generate release notes for delta since latest release of each chart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.4
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Songmu/retry v0.1.0
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/go-github/v56 v56.0.0
 	github.com/magefile/mage v1.15.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=


### PR DESCRIPTION
Change the way `--generate-release-notes` works. 

If `--release-notes-file` exists, then `--generate-release-notes` is ignored. It was previously appended after the release notes file's contents in the release description.

Else if `--generate-release-notes`, then use the GitHub API to generate notes for the delta between the latest release of the chart and the current commit which will be the next release.

Else, as before, use the chart metadata description as the release description.

resolves https://github.com/helm/chart-releaser-action/issues/44

---

The proposed change allows `cr` to focus release notes on the relevant pull requests since the latest release of the same chart. Combined with a [`.github/release.yml`](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options), the generated notes can be further narrowed to ensure they only include pull requests for the specific chart. This requires labeling PRs which can be done automatically based on changed files in a pull request or manually.

I'll provide an functioning example using these elements before marking this PR as "ready for review."