### PR TITLE
Do not merge upstream: Removes ghcr publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,12 +53,12 @@ jobs:
 
       - uses: chainguard-dev/actions/goimports@main
 
-      - name: Login to registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # - name: Login to registry
+      #   uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      #   with:
+      #     registry: quay.io
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Run Mage
         uses: magefile/mage-action@6a5dcb5fe61f43d7c08a98bc3cf9bc63c308c08e # v3.0.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,9 +38,9 @@ builds:
         goarch: ppc64le
     ldflags:
       - >-
-        -X github.com/helm/chart-releaser/cr/cmd.Version={{ .Tag }}
-        -X github.com/helm/chart-releaser/cr/cmd.GitCommit={{ .Commit }}
-        -X github.com/helm/chart-releaser/cr/cmd.BuildDate={{ .Date }}
+        -X github.com/incontact/chart-releaser/cr/cmd.Version={{ .Tag }}
+        -X github.com/incontact/chart-releaser/cr/cmd.GitCommit={{ .Commit }}
+        -X github.com/incontact/chart-releaser/cr/cmd.BuildDate={{ .Date }}
 
 archives:
   - format_overrides:
@@ -58,14 +58,14 @@ snapshot:
 dockers:
   - goos: linux
     goarch: amd64
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
-      - quay.io/helmpack/chart-releaser:latest-amd64
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-amd64
-      - ghcr.io/helm/chart-releaser:latest-amd64
+      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
+      # - quay.io/helmpack/chart-releaser:latest-amd64
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
+      - ghcr.io/incontact/chart-releaser:latest-amd64
     build_flag_templates:
       - "--platform=linux/amd64"
       - --label=org.label-schema.schema-version=1.0
@@ -77,14 +77,14 @@ dockers:
 
   - goos: linux
     goarch: arm64
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
-      - quay.io/helmpack/chart-releaser:latest-arm64
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-arm64
-      - ghcr.io/helm/chart-releaser:latest-arm64
+      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
+      # - quay.io/helmpack/chart-releaser:latest-arm64
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
+      - ghcr.io/incontact/chart-releaser:latest-arm64
     build_flag_templates:
       - "--platform=linux/arm64"
       - --label=org.label-schema.schema-version=1.0
@@ -97,14 +97,14 @@ dockers:
   - goos: linux
     goarch: arm
     goarm: 7
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
-      - quay.io/helmpack/chart-releaser:latest-armv7
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-armv7
-      - ghcr.io/helm/chart-releaser:latest-armv7
+      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
+      # - quay.io/helmpack/chart-releaser:latest-armv7
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
+      - ghcr.io/incontact/chart-releaser:latest-armv7
     build_flag_templates:
       - "--platform=linux/arm/v7"
       - --label=org.label-schema.schema-version=1.0
@@ -116,14 +116,14 @@ dockers:
 
   - goos: linux
     goarch: s390x
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
-      - quay.io/helmpack/chart-releaser:latest-s390x
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-s390x
-      - ghcr.io/helm/chart-releaser:latest-s390x
+      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
+      # - quay.io/helmpack/chart-releaser:latest-s390x
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
+      - ghcr.io/incontact/chart-releaser:latest-s390x
     build_flag_templates:
       - "--platform=linux/s390x"
       - --label=org.label-schema.schema-version=1.0
@@ -135,14 +135,14 @@ dockers:
 
   - goos: linux
     goarch: ppc64le
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
-      - quay.io/helmpack/chart-releaser:latest-ppc64le
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-ppc64le
-      - ghcr.io/helm/chart-releaser:latest-ppc64le
+      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
+      # - quay.io/helmpack/chart-releaser:latest-ppc64le
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
+      - ghcr.io/incontact/chart-releaser:latest-ppc64le
     build_flag_templates:
       - "--platform=linux/ppc64le"
       - --label=org.label-schema.schema-version=1.0
@@ -153,34 +153,34 @@ dockers:
       - --label=org.label-schema.vendor=Helm
 
 docker_manifests:
-  - name_template: quay.io/helmpack/chart-releaser:{{ .Tag }}
+  # - name_template: quay.io/helmpack/chart-releaser:{{ .Tag }}
+  #   image_templates:
+  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
+  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
+  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
+  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
+  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
+  - name_template: ghcr.io/incontact/chart-releaser:{{ .Tag }}
     image_templates:
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
-      - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
-  - name_template: ghcr.io/helm/chart-releaser:{{ .Tag }}
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
+      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
+  # - name_template: quay.io/helmpack/chart-releaser:latest
+  #   image_templates:
+  #     - quay.io/helmpack/chart-releaser:latest-amd64
+  #     - quay.io/helmpack/chart-releaser:latest-arm64
+  #     - quay.io/helmpack/chart-releaser:latest-armv7
+  #     - quay.io/helmpack/chart-releaser:latest-s390x
+  #     - quay.io/helmpack/chart-releaser:latest-ppc64le
+  - name_template: ghcr.io/incontact/chart-releaser:latest
     image_templates:
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-amd64
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-arm64
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-armv7
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-s390x
-      - ghcr.io/helm/chart-releaser:{{ .Tag }}-ppc64le
-  - name_template: quay.io/helmpack/chart-releaser:latest
-    image_templates:
-      - quay.io/helmpack/chart-releaser:latest-amd64
-      - quay.io/helmpack/chart-releaser:latest-arm64
-      - quay.io/helmpack/chart-releaser:latest-armv7
-      - quay.io/helmpack/chart-releaser:latest-s390x
-      - quay.io/helmpack/chart-releaser:latest-ppc64le
-  - name_template: ghcr.io/helm/chart-releaser:latest
-    image_templates:
-      - ghcr.io/helm/chart-releaser:latest-amd64
-      - ghcr.io/helm/chart-releaser:latest-arm64
-      - ghcr.io/helm/chart-releaser:latest-armv7
-      - ghcr.io/helm/chart-releaser:latest-s390x
-      - ghcr.io/helm/chart-releaser:latest-ppc64le
+      - ghcr.io/incontact/chart-releaser:latest-amd64
+      - ghcr.io/incontact/chart-releaser:latest-arm64
+      - ghcr.io/incontact/chart-releaser:latest-armv7
+      - ghcr.io/incontact/chart-releaser:latest-s390x
+      - ghcr.io/incontact/chart-releaser:latest-ppc64le
 
 signs:
   - id: all
@@ -196,17 +196,17 @@ docker_signs:
     args: ["sign", "${artifact}"]
     artifacts: manifests
 
-brews:
-  - repository:
-      owner: helm
-      name: homebrew-tap
-    commit_author:
-      name: helm-bot
-      email: helm-bot@users.noreply.github.com
-    directory: Formula
-    homepage: "{{ .GitURL }}"
-    description: Hosting Helm Charts via GitHub Pages and Releases
-    install: |
-      bin.install "cr"
-    test: |
-      system "#{bin}/cr version"
+# brews:
+#   - repository:
+#       owner: helm
+#       name: homebrew-tap
+#     commit_author:
+#       name: helm-bot
+#       email: helm-bot@users.noreply.github.com
+#     directory: Formula
+#     homepage: "{{ .GitURL }}"
+#     description: Hosting Helm Charts via GitHub Pages and Releases
+#     install: |
+#       bin.install "cr"
+#     test: |
+#       system "#{bin}/cr version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -190,6 +190,11 @@ signs:
     args: ["sign-blob", "--output-signature", "${artifact}.sig", "--output-certificate", "${artifact}.pem", "${artifact}"]
     artifacts: all
 
+release:
+  github:
+    owner: incontact
+    name: chart-releaser
+
 # docker_signs:
 #   - id: images
 #     cmd: cosign

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,132 +55,132 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
-dockers:
-  - goos: linux
-    goarch: amd64
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
-      # - quay.io/helmpack/chart-releaser:latest-amd64
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
-      - ghcr.io/incontact/chart-releaser:latest-amd64
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+# dockers:
+#   - goos: linux
+#     goarch: amd64
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
+#       - quay.io/helmpack/chart-releaser:latest-amd64
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
+#       - ghcr.io/incontact/chart-releaser:latest-amd64
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-  - goos: linux
-    goarch: arm64
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
-      # - quay.io/helmpack/chart-releaser:latest-arm64
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
-      - ghcr.io/incontact/chart-releaser:latest-arm64
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+#   - goos: linux
+#     goarch: arm64
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
+#       - quay.io/helmpack/chart-releaser:latest-arm64
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
+#       - ghcr.io/incontact/chart-releaser:latest-arm64
+#     build_flag_templates:
+#       - "--platform=linux/arm64"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-  - goos: linux
-    goarch: arm
-    goarm: 7
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
-      # - quay.io/helmpack/chart-releaser:latest-armv7
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
-      - ghcr.io/incontact/chart-releaser:latest-armv7
-    build_flag_templates:
-      - "--platform=linux/arm/v7"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+#   - goos: linux
+#     goarch: arm
+#     goarm: 7
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
+#       - quay.io/helmpack/chart-releaser:latest-armv7
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
+#       - ghcr.io/incontact/chart-releaser:latest-armv7
+#     build_flag_templates:
+#       - "--platform=linux/arm/v7"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-  - goos: linux
-    goarch: s390x
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
-      # - quay.io/helmpack/chart-releaser:latest-s390x
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
-      - ghcr.io/incontact/chart-releaser:latest-s390x
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+#   - goos: linux
+#     goarch: s390x
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
+#       - quay.io/helmpack/chart-releaser:latest-s390x
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
+#       - ghcr.io/incontact/chart-releaser:latest-s390x
+#     build_flag_templates:
+#       - "--platform=linux/s390x"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-  - goos: linux
-    goarch: ppc64le
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
-      # - quay.io/helmpack/chart-releaser:latest-ppc64le
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
-      - ghcr.io/incontact/chart-releaser:latest-ppc64le
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+#   - goos: linux
+#     goarch: ppc64le
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
+#       - quay.io/helmpack/chart-releaser:latest-ppc64le
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
+#       - ghcr.io/incontact/chart-releaser:latest-ppc64le
+#     build_flag_templates:
+#       - "--platform=linux/ppc64le"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-docker_manifests:
-  # - name_template: quay.io/helmpack/chart-releaser:{{ .Tag }}
-  #   image_templates:
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
-  - name_template: ghcr.io/incontact/chart-releaser:{{ .Tag }}
-    image_templates:
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
-  # - name_template: quay.io/helmpack/chart-releaser:latest
-  #   image_templates:
-  #     - quay.io/helmpack/chart-releaser:latest-amd64
-  #     - quay.io/helmpack/chart-releaser:latest-arm64
-  #     - quay.io/helmpack/chart-releaser:latest-armv7
-  #     - quay.io/helmpack/chart-releaser:latest-s390x
-  #     - quay.io/helmpack/chart-releaser:latest-ppc64le
-  - name_template: ghcr.io/incontact/chart-releaser:latest
-    image_templates:
-      - ghcr.io/incontact/chart-releaser:latest-amd64
-      - ghcr.io/incontact/chart-releaser:latest-arm64
-      - ghcr.io/incontact/chart-releaser:latest-armv7
-      - ghcr.io/incontact/chart-releaser:latest-s390x
-      - ghcr.io/incontact/chart-releaser:latest-ppc64le
+# docker_manifests:
+#   - name_template: quay.io/helmpack/chart-releaser:{{ .Tag }}
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
+#   - name_template: ghcr.io/incontact/chart-releaser:{{ .Tag }}
+#     image_templates:
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
+#   - name_template: quay.io/helmpack/chart-releaser:latest
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:latest-amd64
+#       - quay.io/helmpack/chart-releaser:latest-arm64
+#       - quay.io/helmpack/chart-releaser:latest-armv7
+#       - quay.io/helmpack/chart-releaser:latest-s390x
+#       - quay.io/helmpack/chart-releaser:latest-ppc64le
+#   - name_template: ghcr.io/incontact/chart-releaser:latest
+#     image_templates:
+#       - ghcr.io/incontact/chart-releaser:latest-amd64
+#       - ghcr.io/incontact/chart-releaser:latest-arm64
+#       - ghcr.io/incontact/chart-releaser:latest-armv7
+#       - ghcr.io/incontact/chart-releaser:latest-s390x
+#       - ghcr.io/incontact/chart-releaser:latest-ppc64le
 
 signs:
   - id: all
@@ -190,11 +190,11 @@ signs:
     args: ["sign-blob", "--output-signature", "${artifact}.sig", "--output-certificate", "${artifact}.pem", "${artifact}"]
     artifacts: all
 
-docker_signs:
-  - id: images
-    cmd: cosign
-    args: ["sign", "${artifact}"]
-    artifacts: manifests
+# docker_signs:
+#   - id: images
+#     cmd: cosign
+#     args: ["sign", "${artifact}"]
+#     artifacts: manifests
 
 # brews:
 #   - repository:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
+# Notice
+This fork is intended to only exist until this issue gets solved in the upstream repo: [Multiple helm charts are not supported](https://github.com/helm/chart-releaser/issues/411)
+
 # Chart Releaser
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-![CI](https://github.com/helm/chart-releaser/workflows/CI/badge.svg?branch=main&event=push)
+![CI](https://github.com/incontact/chart-releaser/workflows/CI/badge.svg?branch=main&event=push)
 
 **Helps Turn GitHub Repositories into Helm Chart Repositories**
 
@@ -11,7 +14,7 @@
 
 ### Binaries (recommended)
 
-Download your preferred asset from the [releases page](https://github.com/helm/chart-releaser/releases) and install manually.
+Download your preferred asset from the [releases page](https://github.com/incontact/chart-releaser/releases) and install manually.
 
 ### Homebrew
 
@@ -25,7 +28,7 @@ $ brew install chart-releaser
 ```console
 // clone repo to some directory outside GOPATH
 
-$ git clone https://github.com/helm/chart-releaser
+$ git clone https://github.com/incontact/chart-releaser
 $ cd chart-releaser
 $ go mod download
 $ go install ./...
@@ -73,7 +76,7 @@ Unfortuntely the releaser-tool won't automatically add repositories for dependen
           helm repo add bitnami-pre2022 https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: incontact/chart-releaser-action@v1.6.0
         with:
           charts_dir: config/helm-chart
         env:
@@ -149,7 +152,7 @@ Global Flags:
 
 When using this tool on a private repository, helm is unable to download the chart package files. When you give Helm your username and password it uses it to authenticate to the repository (the index file). The index file then tells Helm where to get the tarball. If the tarball is hosted in some other location (Github Releases in this case) then it would require a second authentication (which Helm does not support). The solution is to host the files in the same place as your index file and make the links relative paths so there is no need for the second authentication.
 
-[#123](https://github.com/helm/chart-releaser/pull/123) solve this by adding a `--packages-with-index` flag to the upload and index commands.
+[#123](https://github.com/incontact/chart-releaser/pull/123) solve this by adding a `--packages-with-index` flag to the upload and index commands.
 
 ### Prerequisites
 
@@ -285,7 +288,7 @@ During the upload, you can get the following error :
 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
 ```
 
-You can solve it by adding the `--skip-existing` flag to your command. More details can be found in [#101](https://github.com/helm/chart-releaser/issues/101#issuecomment-766410614) and in [#111](https://github.com/helm/chart-releaser/pull/111) that solved this.
+You can solve it by adding the `--skip-existing` flag to your command. More details can be found in [#101](https://github.com/incontact/chart-releaser/issues/101#issuecomment-766410614) and in [#111](https://github.com/incontact/chart-releaser/pull/111) that solved this.
 
 ## Known Bug
 

--- a/cr/cmd/index.go
+++ b/cr/cmd/index.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/helm/chart-releaser/pkg/config"
-	"github.com/helm/chart-releaser/pkg/git"
-	"github.com/helm/chart-releaser/pkg/github"
-	"github.com/helm/chart-releaser/pkg/releaser"
+	"github.com/incontact/chart-releaser/pkg/config"
+	"github.com/incontact/chart-releaser/pkg/git"
+	"github.com/incontact/chart-releaser/pkg/github"
+	"github.com/incontact/chart-releaser/pkg/releaser"
 	"github.com/spf13/cobra"
 )
 

--- a/cr/cmd/package.go
+++ b/cr/cmd/package.go
@@ -15,8 +15,8 @@
 package cmd
 
 import (
-	"github.com/helm/chart-releaser/pkg/config"
-	"github.com/helm/chart-releaser/pkg/packager"
+	"github.com/incontact/chart-releaser/pkg/config"
+	"github.com/incontact/chart-releaser/pkg/packager"
 	"github.com/spf13/cobra"
 )
 

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -15,10 +15,10 @@
 package cmd
 
 import (
-	"github.com/helm/chart-releaser/pkg/config"
-	"github.com/helm/chart-releaser/pkg/git"
-	"github.com/helm/chart-releaser/pkg/github"
-	"github.com/helm/chart-releaser/pkg/releaser"
+	"github.com/incontact/chart-releaser/pkg/config"
+	"github.com/incontact/chart-releaser/pkg/git"
+	"github.com/incontact/chart-releaser/pkg/github"
+	"github.com/incontact/chart-releaser/pkg/releaser"
 	"github.com/spf13/cobra"
 )
 

--- a/cr/main.go
+++ b/cr/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "github.com/helm/chart-releaser/cr/cmd"
+import "github.com/incontact/chart-releaser/cr/cmd"
 
 func main() {
 	cmd.Execute()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/helm/chart-releaser
+module github.com/incontact/chart-releaser
 
 go 1.22.0
 

--- a/pkg/packager/packager.go
+++ b/pkg/packager/packager.go
@@ -25,7 +25,7 @@ import (
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
 
-	"github.com/helm/chart-releaser/pkg/config"
+	"github.com/incontact/chart-releaser/pkg/config"
 	"github.com/mitchellh/go-homedir"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/registry"

--- a/pkg/packager/packager_test.go
+++ b/pkg/packager/packager_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/helm/chart-releaser/pkg/config"
+	"github.com/incontact/chart-releaser/pkg/config"
 )
 
 func TestPackager_CreatePackages(t *testing.T) {

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -36,12 +36,12 @@ import (
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chart/loader"
 
-	"github.com/helm/chart-releaser/pkg/config"
+	"github.com/incontact/chart-releaser/pkg/config"
 
 	"helm.sh/helm/v3/pkg/provenance"
 	"helm.sh/helm/v3/pkg/repo"
 
-	"github.com/helm/chart-releaser/pkg/github"
+	"github.com/incontact/chart-releaser/pkg/github"
 )
 
 // GitHub contains the functions necessary for interacting with GitHub release

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -510,13 +510,17 @@ func TestReleaser_ReleaseNotes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeGitHub := new(FakeGitHub)
+			fakeGit := new(FakeGit)
 			r := &Releaser{
 				config: &config.Options{
 					PackagePath:      "testdata/release-packages",
 					ReleaseNotesFile: tt.releaseNotesFile,
 				},
 				github: fakeGitHub,
+				git:    fakeGit,
 			}
+			fakeGit.On("AddWorktree", mock.Anything, mock.Anything).Return("/tmp/chart-releaser-012345678", nil)
+			fakeGit.On("RemoveWorktree", mock.Anything, mock.Anything).Return(nil)
 			fakeGitHub.On("CreateRelease", mock.Anything, mock.Anything).Return(nil)
 			err := r.CreateReleases()
 			assert.NoError(t, err)

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -21,13 +21,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/helm/chart-releaser/pkg/github"
+	"github.com/incontact/chart-releaser/pkg/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"helm.sh/helm/v3/pkg/provenance"
 	"helm.sh/helm/v3/pkg/repo"
 
-	"github.com/helm/chart-releaser/pkg/config"
+	"github.com/incontact/chart-releaser/pkg/config"
 )
 
 type FakeGitHub struct {


### PR DESCRIPTION
Public docker repos have been disabled for the org, and we only need the binaries for the github action to work.