### PR TITLE
add existing CI TOKEN to access/push brew update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,3 +75,4 @@ jobs:
           args: -v release
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CI_HOMEBREW_TOKEN: "${{ secrets.CI_TOKEN }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -200,6 +200,7 @@ brews:
   - repository:
       owner: helm
       name: homebrew-tap
+      token: "{{ .Env.CI_HOMEBREW_TOKEN }}"
     commit_author:
       name: helm-bot
       email: helm-bot@users.noreply.github.com


### PR DESCRIPTION
ass this repo/github actions does not have access to homebrew-tap repo, we need to have a PAT with that permissions, we have already that secret, will bring back that to push the formula update

see error https://github.com/helm/chart-releaser/actions/runs/12390050554/job/34584290326