### PR TITLE
fix: support repositories with immutable releases enabled

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -134,7 +134,8 @@ func (c *Client) CreateRelease(_ context.Context, input *Release) error {
 	// Publish the release by setting draft to false
 	draft = false
 	req = &github.RepositoryRelease{
-		Draft: &draft,
+		MakeLatest: &input.MakeLatest,
+		Draft:      &draft,
 	}
 	_, _, err = c.Repositories.EditRelease(context.TODO(), c.owner, c.repo, *release.ID, req)
 	if err != nil {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -102,8 +102,14 @@ func (c *Client) GetRelease(_ context.Context, tag string) (*Release, error) {
 	return result, nil
 }
 
-// CreateRelease creates a new release object in the GitHub API
+// CreateRelease creates a new release object in the GitHub API.
+// To support repositories with immutable releases enabled (see
+// https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/),
+// the release is first created as a draft, assets are uploaded, and then
+// the release is published. This ensures that assets can be uploaded before
+// the release becomes immutable.
 func (c *Client) CreateRelease(_ context.Context, input *Release) error {
+	draft := true
 	req := &github.RepositoryRelease{
 		Name:                 &input.Name,
 		Body:                 &input.Description,
@@ -111,6 +117,7 @@ func (c *Client) CreateRelease(_ context.Context, input *Release) error {
 		TargetCommitish:      &input.Commit,
 		GenerateReleaseNotes: &input.GenerateReleaseNotes,
 		MakeLatest:           &input.MakeLatest,
+		Draft:                &draft,
 	}
 
 	release, _, err := c.Repositories.CreateRelease(context.TODO(), c.owner, c.repo, req)
@@ -123,6 +130,17 @@ func (c *Client) CreateRelease(_ context.Context, input *Release) error {
 			return err
 		}
 	}
+
+	// Publish the release by setting draft to false
+	draft = false
+	req = &github.RepositoryRelease{
+		Draft: &draft,
+	}
+	_, _, err = c.Repositories.EditRelease(context.TODO(), c.owner, c.repo, *release.ID, req)
+	if err != nil {
+		return errors.Wrap(err, "failed to publish release")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

GitHub's immutable releases feature (GA since Oct 2025) prevents modifying release artifacts after the release is created. This broke chart-releaser because it creates the release first, then uploads assets in a separate API call.

This fix creates releases as drafts first, uploads assets, then publishes the release. Draft releases can be modified until they are published, which allows the asset upload to succeed.

## Changes

- Modified `CreateRelease` in `pkg/github/github.go` to:
  1. Create releases as drafts (`Draft: true`)
  2. Upload all assets
  3. Publish the release by setting `Draft: false`

## Related Issues

- Fixes https://github.com/helm/chart-releaser-action/issues/228

## References

- https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/