### PR TITLE
add push to oci registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Available Commands:
   help        Help about any command
   index       Update Helm repo index.yaml for the given GitHub repo
   package     Package Helm charts
+  push        Push Helm chart packages to an OCI registry
   upload      Upload Helm chart packages to GitHub Releases
   version     Print version information
 
@@ -110,6 +111,54 @@ Flags:
 
 Global Flags:
       --config string   Config file (default is $HOME/.cr.yaml)
+```
+
+### Push Chart Packages to an OCI Registry
+
+Pushes every chart package found under `--package-path` to an OCI registry as
+`<registry-url>/<chart-name>:<chart-version>`. Sibling `*.tgz.prov` provenance
+files (produced by `cr package --sign`) are pushed automatically.
+
+Credentials are read from the `--username`/`--password` flags (also
+`CR_USERNAME` / `CR_PASSWORD` env vars) when provided; otherwise the registry
+credentials store (`~/.docker/config.json`, populated by `helm registry login`
+or `docker login`) is used.
+
+```console
+$ cr push --help
+Push Helm chart packages to an OCI registry.
+
+For every *.tgz file found under --package-path, the command pushes the chart
+to <registry-url>/<chart-name>:<chart-version>. If a sibling *.tgz.prov
+provenance file is present, it is pushed automatically.
+
+Usage:
+  cr push [flags]
+
+Flags:
+      --ca-file string             Verify registry certificate using this CA bundle
+      --cert-file string           Identify registry client using this TLS certificate file
+  -h, --help                       help for push
+      --insecure-skip-tls-verify   Skip TLS certificate verification
+      --key-file string            Identify registry client using this TLS key file
+  -p, --package-path string        Path to directory with chart packages (default ".cr-release-packages")
+      --password string            Registry password (falls back to ~/.docker/config.json if unset)
+      --plain-http                 Use insecure HTTP connections
+  -r, --registry-url string        OCI registry URL (e.g. oci://ghcr.io/myorg/charts)
+      --skip-existing              Skip pushing chart versions that already exist in the registry
+  -u, --username string            Registry username (falls back to ~/.docker/config.json if unset)
+
+Global Flags:
+      --config string   Config file (default is $HOME/.cr.yaml)
+```
+
+Example:
+
+```bash
+cr push --registry-url oci://ghcr.io/myorg/charts \
+        --username "$GITHUB_ACTOR" \
+        --password "$GITHUB_TOKEN" \
+        --skip-existing
 ```
 
 ### Create the Repository Index from GitHub Releases

--- a/cr/cmd/push.go
+++ b/cr/cmd/push.go
@@ -1,0 +1,60 @@
+// Copyright The Helm Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/helm/chart-releaser/pkg/config"
+	"github.com/helm/chart-releaser/pkg/pusher"
+	"github.com/spf13/cobra"
+)
+
+var pushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Push Helm chart packages to an OCI registry",
+	Long: `Push Helm chart packages to an OCI registry.
+
+For every *.tgz file found under --package-path, the command pushes the chart
+to <registry-url>/<chart-name>:<chart-version>. If a sibling *.tgz.prov
+provenance file is present, it is pushed automatically.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cfg, err := config.LoadConfiguration(cfgFile, cmd, getRequiredPushArgs())
+		if err != nil {
+			return err
+		}
+		return pusher.NewPusher(cfg).PushPackages()
+	},
+}
+
+func getRequiredPushArgs() []string {
+	// registry-url is validated inside the pusher so we can give a helpful
+	// scheme-specific error message. The reflect-based required-flag check in
+	// config.LoadConfiguration cannot resolve the RegistryURL field (the
+	// generic kebab-case helper lowercases the URL acronym).
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(pushCmd)
+	pushCmd.Flags().StringP("registry-url", "r", "", "OCI registry URL (e.g. oci://ghcr.io/myorg/charts)")
+	pushCmd.Flags().StringP("package-path", "p", ".cr-release-packages", "Path to directory with chart packages")
+	pushCmd.Flags().StringP("username", "u", "", "Registry username (falls back to ~/.docker/config.json if unset)")
+	pushCmd.Flags().String("password", "", "Registry password (falls back to ~/.docker/config.json if unset)")
+	pushCmd.Flags().Bool("skip-existing", false, "Skip pushing chart versions that already exist in the registry")
+	pushCmd.Flags().Bool("plain-http", false, "Use insecure HTTP connections")
+	pushCmd.Flags().Bool("insecure-skip-tls-verify", false, "Skip TLS certificate verification")
+	pushCmd.Flags().String("ca-file", "", "Verify registry certificate using this CA bundle")
+	pushCmd.Flags().String("cert-file", "", "Identify registry client using this TLS certificate file")
+	pushCmd.Flags().String("key-file", "", "Identify registry client using this TLS key file")
+}

--- a/doc/cr.md
+++ b/doc/cr.md
@@ -21,6 +21,7 @@ and Chart metadata to GitHub Releases and creating a suitable index file
 * [cr completion](cr_completion.md)	 - Generate the autocompletion script for the specified shell
 * [cr index](cr_index.md)	 - Update Helm repo index.yaml for the given GitHub repo
 * [cr package](cr_package.md)	 - Package Helm charts
+* [cr push](cr_push.md)	 - Push Helm chart packages to an OCI registry
 * [cr upload](cr_upload.md)	 - Upload Helm chart packages to GitHub Releases
 * [cr version](cr_version.md)	 - Print version information
 

--- a/doc/cr_push.md
+++ b/doc/cr_push.md
@@ -1,0 +1,42 @@
+## cr push
+
+Push Helm chart packages to an OCI registry
+
+### Synopsis
+
+Push Helm chart packages to an OCI registry.
+
+For every *.tgz file found under --package-path, the command pushes the chart
+to <registry-url>/<chart-name>:<chart-version>. If a sibling *.tgz.prov
+provenance file is present, it is pushed automatically.
+
+```
+cr push [flags]
+```
+
+### Options
+
+```
+      --ca-file string             Verify registry certificate using this CA bundle
+      --cert-file string           Identify registry client using this TLS certificate file
+  -h, --help                       help for push
+      --insecure-skip-tls-verify   Skip TLS certificate verification
+      --key-file string            Identify registry client using this TLS key file
+  -p, --package-path string        Path to directory with chart packages (default ".cr-release-packages")
+      --password string            Registry password (falls back to ~/.docker/config.json if unset)
+      --plain-http                 Use insecure HTTP connections
+  -r, --registry-url string        OCI registry URL (e.g. oci://ghcr.io/myorg/charts)
+      --skip-existing              Skip pushing chart versions that already exist in the registry
+  -u, --username string            Registry username (falls back to ~/.docker/config.json if unset)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   Config file (default is $HOME/.cr.yaml)
+```
+
+### SEE ALSO
+
+* [cr](cr.md)	 - Helm Chart Repos on Github Pages
+

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,15 @@ type Options struct {
 	GenerateReleaseNotes bool   `mapstructure:"generate-release-notes"`
 	MakeReleaseLatest    bool   `mapstructure:"make-release-latest"`
 	PackagesWithIndex    bool   `mapstructure:"packages-with-index"`
+
+	RegistryURL           string `mapstructure:"registry-url"`
+	Username              string `mapstructure:"username"`
+	Password              string `mapstructure:"password"`
+	PlainHTTP             bool   `mapstructure:"plain-http"`
+	InsecureSkipTLSVerify bool   `mapstructure:"insecure-skip-tls-verify"`
+	CAFile                string `mapstructure:"ca-file"`
+	CertFile              string `mapstructure:"cert-file"`
+	KeyFile               string `mapstructure:"key-file"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, requiredFlags []string) (*Options, error) {

--- a/pkg/pusher/pusher.go
+++ b/pkg/pusher/pusher.go
@@ -1,0 +1,179 @@
+// Copyright The Helm Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pusher
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/registry"
+
+	"github.com/helm/chart-releaser/pkg/config"
+)
+
+const ociScheme = "oci://"
+
+// Pusher pushes Helm chart packages to an OCI registry.
+type Pusher struct {
+	config *config.Options
+	out    io.Writer
+}
+
+// NewPusher returns a configured Pusher.
+func NewPusher(cfg *config.Options) *Pusher {
+	return &Pusher{config: cfg, out: os.Stdout}
+}
+
+// PushPackages pushes every *.tgz package found under PackagePath to the
+// configured OCI registry. Sibling *.tgz.prov files are picked up
+// automatically by Helm's push action.
+func (p *Pusher) PushPackages() error {
+	if p.config.RegistryURL == "" {
+		return errors.New("'--registry-url' is required")
+	}
+	if !strings.HasPrefix(p.config.RegistryURL, ociScheme) {
+		return fmt.Errorf("registry-url must start with %q (got %q)", ociScheme, p.config.RegistryURL)
+	}
+
+	chartPackages, err := filepath.Glob(filepath.Join(p.config.PackagePath, "*.tgz"))
+	if err != nil {
+		return err
+	}
+	if len(chartPackages) == 0 {
+		return fmt.Errorf("no chart packages found in %s", p.config.PackagePath)
+	}
+
+	registryClient, err := newRegistryClient(p.config)
+	if err != nil {
+		return fmt.Errorf("creating registry client: %w", err)
+	}
+
+	settings := cli.New()
+	cfg := &action.Configuration{RegistryClient: registryClient}
+
+	pushClient := action.NewPushWithOpts(
+		action.WithPushConfig(cfg),
+		action.WithTLSClientConfig(p.config.CertFile, p.config.KeyFile, p.config.CAFile),
+		action.WithInsecureSkipTLSVerify(p.config.InsecureSkipTLSVerify),
+		action.WithPlainHTTP(p.config.PlainHTTP),
+		action.WithPushOptWriter(p.out),
+	)
+	pushClient.Settings = settings
+
+	remote := strings.TrimRight(p.config.RegistryURL, "/")
+
+	for _, chartPackage := range chartPackages {
+		if p.config.SkipExisting {
+			exists, err := chartExists(registryClient, remote, chartPackage)
+			if err != nil {
+				return fmt.Errorf("checking %s in registry: %w", chartPackage, err)
+			}
+			if exists {
+				fmt.Fprintf(p.out, "Skipping %s: already exists in %s\n", chartPackage, remote)
+				continue
+			}
+		}
+
+		output, err := pushClient.Run(chartPackage, remote)
+		if err != nil {
+			return fmt.Errorf("pushing %s to %s: %w", chartPackage, remote, err)
+		}
+		if output != "" {
+			fmt.Fprint(p.out, output)
+		}
+		fmt.Fprintf(p.out, "Successfully pushed %s to %s\n", chartPackage, remote)
+	}
+	return nil
+}
+
+// chartExists reports whether the chart in the given .tgz is already present
+// in the registry at remote. Helm replaces '+' with '_' in version tags;
+// chartExists applies the same substitution before resolving.
+func chartExists(client *registry.Client, remote, chartPackage string) (bool, error) {
+	ch, err := loader.LoadFile(chartPackage)
+	if err != nil {
+		return false, err
+	}
+	ref := fmt.Sprintf("%s/%s:%s",
+		strings.TrimPrefix(remote, ociScheme),
+		ch.Metadata.Name,
+		strings.ReplaceAll(ch.Metadata.Version, "+", "_"),
+	)
+	if _, err := client.Resolve(ref); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func newRegistryClient(cfg *config.Options) (*registry.Client, error) {
+	opts := []registry.ClientOption{
+		registry.ClientOptEnableCache(true),
+		registry.ClientOptWriter(io.Discard),
+		registry.ClientOptBasicAuth(cfg.Username, cfg.Password),
+	}
+
+	useTLS := cfg.CertFile != "" || cfg.KeyFile != "" || cfg.CAFile != "" || cfg.InsecureSkipTLSVerify
+	if useTLS {
+		tlsConf, err := newClientTLS(cfg.CertFile, cfg.KeyFile, cfg.CAFile, cfg.InsecureSkipTLSVerify)
+		if err != nil {
+			return nil, fmt.Errorf("building TLS config: %w", err)
+		}
+		opts = append(opts, registry.ClientOptHTTPClient(&http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConf,
+				Proxy:           http.ProxyFromEnvironment,
+			},
+		}))
+	}
+	if cfg.PlainHTTP {
+		opts = append(opts, registry.ClientOptPlainHTTP())
+	}
+
+	return registry.NewClient(opts...)
+}
+
+func newClientTLS(certFile, keyFile, caFile string, insecureSkipTLSVerify bool) (*tls.Config, error) {
+	c := &tls.Config{InsecureSkipVerify: insecureSkipTLSVerify} // #nosec G402 -- gated by --insecure-skip-tls-verify flag
+
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading key pair from %s and %s: %w", certFile, keyFile, err)
+		}
+		c.Certificates = []tls.Certificate{cert}
+	}
+	if caFile != "" {
+		b, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading CA file %s: %w", caFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(b) {
+			return nil, fmt.Errorf("no certificates found in CA file %s", caFile)
+		}
+		c.RootCAs = pool
+	}
+	return c, nil
+}

--- a/pkg/pusher/pusher_test.go
+++ b/pkg/pusher/pusher_test.go
@@ -1,0 +1,101 @@
+// Copyright The Helm Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pusher
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/action"
+
+	"github.com/helm/chart-releaser/pkg/config"
+)
+
+func TestPushPackages_RegistryURLRequired(t *testing.T) {
+	p := &Pusher{
+		config: &config.Options{RegistryURL: "", PackagePath: t.TempDir()},
+		out:    &bytes.Buffer{},
+	}
+	err := p.PushPackages()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'--registry-url' is required")
+}
+
+func TestPushPackages_ValidatesScheme(t *testing.T) {
+	tests := []struct {
+		name        string
+		registryURL string
+	}{
+		{"http", "http://example.com/charts"},
+		{"https", "https://example.com/charts"},
+		{"no scheme", "example.com/charts"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Pusher{
+				config: &config.Options{RegistryURL: tt.registryURL, PackagePath: t.TempDir()},
+				out:    &bytes.Buffer{},
+			}
+			err := p.PushPackages()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "registry-url must start with")
+		})
+	}
+}
+
+func TestPushPackages_NoPackagesFound(t *testing.T) {
+	p := &Pusher{
+		config: &config.Options{
+			RegistryURL: "oci://example.com/charts",
+			PackagePath: t.TempDir(),
+		},
+		out: &bytes.Buffer{},
+	}
+	err := p.PushPackages()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no chart packages found")
+}
+
+func TestPushPackages_PushFailsAgainstUnreachableRegistry(t *testing.T) {
+	packageDir := t.TempDir()
+	tgz := packageTestChart(t, packageDir)
+
+	p := &Pusher{
+		config: &config.Options{
+			RegistryURL: "oci://127.0.0.1:1/charts",
+			PackagePath: packageDir,
+			PlainHTTP:   true,
+		},
+		out: &bytes.Buffer{},
+	}
+	err := p.PushPackages()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pushing "+tgz)
+}
+
+// packageTestChart packages testdata/test-chart into dest and returns the
+// resulting .tgz path. It uses helm's own packager so the artifact is a
+// real chart archive a registry could accept.
+func packageTestChart(t *testing.T, dest string) string {
+	t.Helper()
+	packageClient := action.NewPackage()
+	packageClient.Destination = dest
+	out, err := packageClient.Run("testdata/test-chart", nil)
+	require.NoError(t, err)
+	return filepath.Clean(out)
+}

--- a/pkg/pusher/testdata/test-chart/.helmignore
+++ b/pkg/pusher/testdata/test-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pkg/pusher/testdata/test-chart/Chart.yaml
+++ b/pkg/pusher/testdata/test-chart/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: test-chart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/pkg/pusher/testdata/test-chart/templates/NOTES.txt
+++ b/pkg/pusher/testdata/test-chart/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "test-chart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "test-chart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "test-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "test-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/pkg/pusher/testdata/test-chart/templates/_helpers.tpl
+++ b/pkg/pusher/testdata/test-chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "test-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "test-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "test-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "test-chart.labels" -}}
+helm.sh/chart: {{ include "test-chart.chart" . }}
+{{ include "test-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "test-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "test-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "test-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "test-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/pkg/pusher/testdata/test-chart/templates/deployment.yaml
+++ b/pkg/pusher/testdata/test-chart/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "test-chart.fullname" . }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "test-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "test-chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "test-chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/pkg/pusher/testdata/test-chart/templates/hpa.yaml
+++ b/pkg/pusher/testdata/test-chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "test-chart.fullname" . }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "test-chart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/pkg/pusher/testdata/test-chart/templates/ingress.yaml
+++ b/pkg/pusher/testdata/test-chart/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "test-chart.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/pkg/pusher/testdata/test-chart/templates/service.yaml
+++ b/pkg/pusher/testdata/test-chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "test-chart.fullname" . }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "test-chart.selectorLabels" . | nindent 4 }}

--- a/pkg/pusher/testdata/test-chart/templates/serviceaccount.yaml
+++ b/pkg/pusher/testdata/test-chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "test-chart.serviceAccountName" . }}
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/pkg/pusher/testdata/test-chart/templates/tests/test-connection.yaml
+++ b/pkg/pusher/testdata/test-chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "test-chart.fullname" . }}-test-connection"
+  labels:
+    {{- include "test-chart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "test-chart.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/pkg/pusher/testdata/test-chart/values.yaml
+++ b/pkg/pusher/testdata/test-chart/values.yaml
@@ -1,0 +1,79 @@
+# Default values for test-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## add push to oci registries

Closes #183.

Adds a new `cr push` command that uploads every chart package in `--package-path`
to an OCI registry. Built on top of `helm.sh/helm/v3/pkg/action.NewPushWithOpts`
— the same code path the `helm push` CLI uses — so behavior, auth handling, and
provenance support stay in lockstep with Helm.

This is an independent distribution channel: `cr push` does not touch the
gh-pages branch, the `index.yaml`, or GitHub Releases. Users can run OCI-only
or dual-publish alongside `cr upload`.

## What's new

- **`cr push`** command. Iterates `*.tgz` files under `--package-path` and
  pushes each to `<registry-url>/<chart-name>:<chart-version>`. Sibling
  `*.tgz.prov` files (from `cr package --sign`) are picked up automatically.
- **Auth**: `--username` / `--password` flags (also `CR_USERNAME` /
  `CR_PASSWORD` via the existing viper env-binding); falls back to the
  registry credential store (`~/.docker/config.json`, populated by
  `helm registry login` or `docker login`).
- **TLS**: full set of flags — `--plain-http`, `--insecure-skip-tls-verify`,
  `--ca-file`, `--cert-file`, `--key-file`.
- **Idempotent re-runs**: `--skip-existing` resolves each chart's OCI ref
  against the registry and skips ones already present. Mirrors
  `cr upload --skip-existing` semantics. Default is off (matches `helm push`).
- **Strict scheme check**: requires `oci://` prefix on `--registry-url` and
  errors out with a helpful message otherwise.

## Usage

```bash
cr package mychart/
cr push \
  --registry-url oci://ghcr.io/myorg/charts \
  --username "$GITHUB_ACTOR" \
  --password "$GITHUB_TOKEN" \
  --skip-existing
``` 

## Follow up

chart-release-action update: https://github.com/helm/chart-releaser-action/pull/234