### PR TITLE
fix: generate release notes against the previous tag of the same chart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/Songmu/retry v0.1.0
 	github.com/google/go-github/v56 v56.0.0
 	github.com/magefile/mage v1.17.2
@@ -21,7 +22,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -126,6 +126,49 @@ func (c *Client) CreateRelease(_ context.Context, input *Release) error {
 	return nil
 }
 
+// GenerateReleaseNotes generates release notes for the given tag, comparing
+// against previousTag. Since the tag may not exist yet at generation time,
+// commit (falling back to the default branch when empty) determines the
+// target of the comparison.
+func (c *Client) GenerateReleaseNotes(_ context.Context, tag string, previousTag string, commit string) (string, error) {
+	opts := &github.GenerateNotesOptions{
+		TagName:         tag,
+		PreviousTagName: &previousTag,
+	}
+	if commit != "" {
+		opts.TargetCommitish = &commit
+	}
+
+	notes, _, err := c.Repositories.GenerateReleaseNotes(context.TODO(), c.owner, c.repo, opts)
+	if err != nil {
+		return "", err
+	}
+	return notes.Body, nil
+}
+
+// ListTagsWithPrefix returns the names of all tags starting with the given prefix
+func (c *Client) ListTagsWithPrefix(_ context.Context, prefix string) ([]string, error) {
+	var tags []string
+	opts := &github.ReferenceListOptions{
+		Ref:         "tags/" + prefix,
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	for {
+		refs, resp, err := c.Git.ListMatchingRefs(context.TODO(), c.owner, c.repo, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, ref := range refs {
+			tags = append(tags, strings.TrimPrefix(ref.GetRef(), "refs/tags/"))
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return tags, nil
+}
+
 // CreatePullRequest creates a pull request in the repository specified by repoURL.
 // The return value is the pull request URL.
 func (c *Client) CreatePullRequest(owner string, repo string, message string, head string, base string) (string, error) {

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/Songmu/retry"
 
 	"text/template"
@@ -50,6 +51,8 @@ type GitHub interface {
 	CreateRelease(ctx context.Context, input *github.Release) error
 	GetRelease(ctx context.Context, tag string) (*github.Release, error)
 	CreatePullRequest(owner string, repo string, message string, head string, base string) (string, error)
+	GenerateReleaseNotes(ctx context.Context, tag string, previousTag string, commit string) (string, error)
+	ListTagsWithPrefix(ctx context.Context, prefix string) ([]string, error)
 }
 
 type Git interface {
@@ -238,6 +241,68 @@ func (r *Releaser) computeReleaseName(chart *chart.Chart) (string, error) {
 	return releaseName, nil
 }
 
+// versionPlaceholder is rendered into the release name template in place of the
+// chart version so the surrounding literal parts of the release name can be
+// determined. The NUL bytes cannot occur in chart names or template output.
+const versionPlaceholder = "\x00version\x00"
+
+// computePreviousReleaseName returns the name of the newest existing release of
+// the same chart with a version lower than the version currently being
+// released, or an empty string if no such release can be determined (e.g. on
+// the first release of a chart or when the release name template does not
+// contain the chart version).
+func (r *Releaser) computePreviousReleaseName(ctx context.Context, chart *chart.Chart) (string, error) {
+	tmpl, err := template.New("gotpl").Parse(r.config.ReleaseNameTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	metadata := *chart.Metadata
+	metadata.Version = versionPlaceholder
+
+	var buffer bytes.Buffer
+	if err := tmpl.Execute(&buffer, &metadata); err != nil {
+		return "", err
+	}
+
+	prefix, suffix, found := strings.Cut(buffer.String(), versionPlaceholder)
+	if !found {
+		return "", nil
+	}
+
+	currentVersion, err := semver.NewVersion(chart.Metadata.Version)
+	if err != nil {
+		return "", nil
+	}
+
+	tags, err := r.github.ListTagsWithPrefix(ctx, prefix)
+	if err != nil {
+		return "", err
+	}
+
+	var previousVersion *semver.Version
+	previousReleaseName := ""
+	for _, tag := range tags {
+		if !strings.HasPrefix(tag, prefix) || !strings.HasSuffix(tag, suffix) || len(tag) < len(prefix)+len(suffix) {
+			continue
+		}
+		version, err := semver.NewVersion(tag[len(prefix) : len(tag)-len(suffix)])
+		if err != nil {
+			// Not a version of this chart, e.g. the tag of another chart
+			// whose name shares this chart's name as a prefix.
+			continue
+		}
+		if !version.LessThan(currentVersion) {
+			continue
+		}
+		if previousVersion == nil || version.GreaterThan(previousVersion) {
+			previousVersion = version
+			previousReleaseName = tag
+		}
+	}
+	return previousReleaseName, nil
+}
+
 func (r *Releaser) getReleaseNotes(chart *chart.Chart) string {
 	if r.config.ReleaseNotesFile != "" {
 		for _, f := range chart.Files {
@@ -338,6 +403,29 @@ func (r *Releaser) CreateReleases() error {
 			existingRelease, _ := r.github.GetRelease(context.TODO(), releaseName)
 			if existingRelease != nil {
 				continue
+			}
+		}
+		if r.config.GenerateReleaseNotes {
+			// GitHub's built-in release notes generation compares against the
+			// chronologically previous tag of the whole repository, which in
+			// repositories with multiple charts is usually a tag of another
+			// chart. Generate the notes explicitly against the previous
+			// release of the same chart instead, falling back to the built-in
+			// behavior when no previous release exists.
+			previousReleaseName, err := r.computePreviousReleaseName(context.TODO(), ch)
+			if err != nil {
+				fmt.Printf("Could not determine the previous release of %s, using GitHub's default release notes: %v\n", releaseName, err)
+			} else if previousReleaseName != "" {
+				notes, err := r.github.GenerateReleaseNotes(context.TODO(), releaseName, previousReleaseName, r.config.Commit)
+				if err != nil {
+					fmt.Printf("Could not generate release notes for %s, using GitHub's default release notes: %v\n", releaseName, err)
+				} else {
+					if release.Description != "" {
+						release.Description += "\n\n"
+					}
+					release.Description += notes
+					release.GenerateReleaseNotes = false
+				}
 			}
 		}
 		if err := r.github.CreateRelease(context.TODO(), release); err != nil {

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -16,6 +16,7 @@ package releaser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/provenance"
 	"helm.sh/helm/v3/pkg/repo"
 
@@ -109,6 +111,16 @@ func (f *FakeGitHub) GetRelease(ctx context.Context, tag string) (*github.Releas
 		},
 	}
 	return release, nil
+}
+
+func (f *FakeGitHub) GenerateReleaseNotes(ctx context.Context, tag string, previousTag string, commit string) (string, error) { //nolint: revive
+	args := f.Called(ctx, tag, previousTag, commit)
+	return args.String(0), args.Error(1)
+}
+
+func (f *FakeGitHub) ListTagsWithPrefix(ctx context.Context, prefix string) ([]string, error) { //nolint: revive
+	args := f.Called(ctx, prefix)
+	return args.Get(0).([]string), args.Error(1)
 }
 
 func (f *FakeGitHub) CreatePullRequest(owner string, repo string, message string, head string, base string) (string, error) {
@@ -533,4 +545,117 @@ func TestReleaser_ReleaseNotes(t *testing.T) {
 			assert.Equal(t, tt.expectedReleaseNotes, fakeGitHub.release.Description)
 		})
 	}
+}
+
+func TestReleaser_computePreviousReleaseName(t *testing.T) {
+	tests := []struct {
+		name         string
+		template     string
+		chartVersion string
+		tags         []string
+		expected     string
+		expectLookup bool
+	}{
+		{
+			name:         "picks-highest-lower-version",
+			template:     "{{ .Name }}-{{ .Version }}",
+			chartVersion: "2.0.0",
+			tags:         []string{"my-chart-1.0.0", "my-chart-1.9.9", "my-chart-2.0.0", "my-chart-2.1.0"},
+			expected:     "my-chart-1.9.9",
+			expectLookup: true,
+		},
+		{
+			name:         "ignores-sibling-chart-sharing-prefix",
+			template:     "{{ .Name }}-{{ .Version }}",
+			chartVersion: "2.0.0",
+			tags:         []string{"my-chart-extra-3.0.0", "my-chart-1.5.0"},
+			expected:     "my-chart-1.5.0",
+			expectLookup: true,
+		},
+		{
+			name:         "first-release-of-chart",
+			template:     "{{ .Name }}-{{ .Version }}",
+			chartVersion: "1.0.0",
+			tags:         []string{},
+			expected:     "",
+			expectLookup: true,
+		},
+		{
+			name:         "considers-prereleases",
+			template:     "{{ .Name }}-{{ .Version }}",
+			chartVersion: "1.0.0",
+			tags:         []string{"my-chart-1.0.0-rc.1"},
+			expected:     "my-chart-1.0.0-rc.1",
+			expectLookup: true,
+		},
+		{
+			name:         "template-without-version",
+			template:     "{{ .Name }}",
+			chartVersion: "2.0.0",
+			expected:     "",
+			expectLookup: false,
+		},
+		{
+			name:         "custom-template-with-prefix-and-suffix",
+			template:     "charts/{{ .Name }}/v{{ .Version }}",
+			chartVersion: "2.0.0",
+			tags:         []string{"charts/my-chart/v1.2.3", "charts/my-chart/vgarbage"},
+			expected:     "charts/my-chart/v1.2.3",
+			expectLookup: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeGitHub := new(FakeGitHub)
+			fakeGitHub.On("ListTagsWithPrefix", mock.Anything, mock.Anything).Return(tt.tags, nil)
+			releaser := &Releaser{
+				config: &config.Options{ReleaseNameTemplate: tt.template},
+				github: fakeGitHub,
+			}
+			testChart := &chart.Chart{Metadata: &chart.Metadata{Name: "my-chart", Version: tt.chartVersion}}
+			previous, err := releaser.computePreviousReleaseName(context.Background(), testChart)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, previous)
+			if !tt.expectLookup {
+				fakeGitHub.AssertNumberOfCalls(t, "ListTagsWithPrefix", 0)
+			}
+		})
+	}
+}
+
+func TestReleaser_CreateReleases_generatedReleaseNotes(t *testing.T) {
+	t.Run("generates-notes-against-previous-chart-release", func(t *testing.T) {
+		fakeGitHub := new(FakeGitHub)
+		fakeGitHub.On("CreateRelease", mock.Anything, mock.Anything).Return(nil)
+		fakeGitHub.On("ListTagsWithPrefix", mock.Anything, "test-chart-").Return([]string{"test-chart-0.0.9", "other-chart-0.1.0"}, nil)
+		fakeGitHub.On("GenerateReleaseNotes", mock.Anything, "test-chart-0.1.0", "test-chart-0.0.9", "").Return("## What's Changed\n* something", nil)
+		releaser := &Releaser{
+			config: &config.Options{
+				PackagePath:          "testdata/release-packages",
+				GenerateReleaseNotes: true,
+				ReleaseNameTemplate:  "{{ .Name }}-{{ .Version }}",
+			},
+			github: fakeGitHub,
+		}
+		assert.NoError(t, releaser.CreateReleases())
+		assert.Equal(t, "A Helm chart for Kubernetes\n\n## What's Changed\n* something", fakeGitHub.release.Description)
+		assert.False(t, fakeGitHub.release.GenerateReleaseNotes)
+	})
+	t.Run("falls-back-to-github-generation-when-lookup-fails", func(t *testing.T) {
+		fakeGitHub := new(FakeGitHub)
+		fakeGitHub.On("CreateRelease", mock.Anything, mock.Anything).Return(nil)
+		fakeGitHub.On("ListTagsWithPrefix", mock.Anything, "test-chart-").Return([]string{}, errors.New("api error"))
+		releaser := &Releaser{
+			config: &config.Options{
+				PackagePath:          "testdata/release-packages",
+				GenerateReleaseNotes: true,
+				ReleaseNameTemplate:  "{{ .Name }}-{{ .Version }}",
+			},
+			github: fakeGitHub,
+		}
+		assert.NoError(t, releaser.CreateReleases())
+		assert.Equal(t, "A Helm chart for Kubernetes", fakeGitHub.release.Description)
+		assert.True(t, fakeGitHub.release.GenerateReleaseNotes)
+		fakeGitHub.AssertNumberOfCalls(t, "GenerateReleaseNotes", 0)
+	})
 }


### PR DESCRIPTION
Fixes #648

## What/Why

In repositories that release multiple charts, GitHub's built-in release notes generation compares against the chronologically previous tag of the whole repository, which is usually a tag of a *different* chart, producing wrong "Full Changelog" links on every release (example in #648, from argoproj/argo-helm). When `generate-release-notes` is enabled, this change determines the previous release of the same chart — tags matched against the release name template with server-side prefix filtering, highest semver below the version being released — and generates the notes explicitly against it via the generate-notes API, appending them after the configured release description in the same position GitHub's built-in generation uses. First releases of a chart, templates without the chart version, and any lookup failure all fall back to the current behavior.

## Proof it works

`go build ./...` and `golangci-lint run` (0 issues) pass. `pkg/releaser` tests pass with new coverage: six `computePreviousReleaseName` table cases (sibling charts sharing a name prefix like `my-chart` vs `my-chart-extra`, prereleases, custom `release-name-template` with prefix and suffix, first release, template without version) and two `CreateReleases` cases covering the generated-notes path and the fallback when tag listing fails.

## Risk + AI role

Low-medium: the new path only runs when `generate-release-notes` is enabled, and every failure mode falls back to today's behavior. AI-assisted, author-reviewed and locally verified.

## Review focus

The previous-tag discovery in `computePreviousReleaseName` (sentinel-based template parsing and semver filtering of sibling-chart tags), and the choice to fix this unconditionally rather than behind a new flag — happy to gate it behind an option if you'd prefer opt-in.
